### PR TITLE
Added generate_param_grid script for tuning

### DIFF
--- a/src/tuning/README.md
+++ b/src/tuning/README.md
@@ -1,0 +1,78 @@
+# Hyperparameter YAML Configuration Guide
+
+This README explains how to define hyperparameters for each forecasting model in YAML format.
+
+## General Structure of a YAML Entry
+
+Each model should be added as a top-level key in the YAML file, with parameters specified as nested keys.
+
+```yaml
+ModelName:
+  parameter_name:
+    type: data_type
+    values: [...]  # or range: [start, end] for numerical params
+```
+
+- **Use `values` for lists of discrete options** (categorical variables).
+- **Use `range` for numerical parameters** (integers or floats).
+
+## Supported Parameter Types & Best Practices
+
+### List (Categorical Parameters)
+- Use when the parameter takes a predefined set of values.
+- Best for options like trend types, seasonal components, or model selection.
+
+Example:
+```yaml
+AutoARIMA:
+  seasonal_order:
+    type: list
+    values: [[0, 1, 1, 7], [1, 1, 1, 12]]
+```
+Best Practice:
+- Include values that align with common seasonal cycles (e.g., 7 for weekly data, 12 for monthly).
+
+### Integer (Discrete Ranges)
+- Use when the parameter is a whole number within a logical range.
+- Best for order selection (e.g., AR, MA terms in ARIMA), tree depths, or iteration counts.
+
+Example:
+```yaml
+AutoARIMA:
+  max_order:
+    type: int
+    range: [1, 5]
+```
+Best Practice:
+- Choose a **reasonable range** (avoid excessive values that may cause overfitting or slow training).
+
+---
+
+### Float (Continuous Ranges)
+- Use when the parameter can take decimal values within a range.
+- Best for learning rates, smoothing factors, or penalty terms.
+
+Example:
+```yaml
+ExpSmoothing:
+  smoothing_level:
+    type: float
+    range: [0.1, 1.0, 0.1]  # Start, End, Step
+```
+Best Practice:
+- Keep the **step size** small enough to explore the space efficiently but not too small (e.g., 0.01 is fine for tuning but 0.0001 may be excessive).
+
+---
+
+### Boolean (True/False Options)
+- Use for settings that toggle features on or off.
+- Best for enabling/disabling trend components, intercepts, or constraints.
+
+Example:
+```yaml
+AutoARIMA:
+  with_intercept:
+    type: bool
+```
+Best Practice:
+- Use booleans only when a setting is explicitly binary.

--- a/src/tuning/configs/modset1.yaml
+++ b/src/tuning/configs/modset1.yaml
@@ -1,0 +1,32 @@
+AutoARIMA:
+  seasonal_order:
+    type: list
+    values: [[0, 1, 1, 7], [1, 1, 1, 7]]
+  max_order:
+    type: int
+    range: [1, 5]
+  with_intercept:
+    type: bool
+    values: [true, false]
+
+ExpSmoothing:
+  trend:
+    type: list
+    values: [add, mul, none]
+  seasonal:
+    type: list
+    values: [add, none]
+  seasonal_periods:
+    type: int
+    range: [2, 12]
+
+NaiveForecaster:
+  strategy:
+    type: list
+    values: ["last", "mean", "drift"]
+  window_length:
+    type: int
+    range: [1, 10]  # Window size for "mean" strategy, ignored for "last"
+  sp:
+    type: int
+    range: [1, 12]  # Seasonal periodicity, useful for monthly/weekly data

--- a/src/tuning/param_grid.py
+++ b/src/tuning/param_grid.py
@@ -1,0 +1,48 @@
+import numpy as np
+from src.utils.config_loader import load_yaml_config
+
+
+def generate_param_grid(model_name, config):
+    """Generate a parameter grid for sktime's ForecastingGridSearchCV.
+
+    Args:
+        model_name (str): Name of the forecasting model (e.g., "AutoARIMA") as listed in config.
+        config (dict): Model-specific hyperparameter settings loaded from YAML.
+
+    Returns:
+        dict: A parameter grid where keys are parameter names and values are lists of possible values.
+
+    Raises:
+        ValueError: If the model is not found in the config or if a parameter type is unsupported.
+    """
+    param_grid = {}
+
+    if model_name not in config:
+        raise ValueError(f"Model '{model_name}' not found in YAML config.")
+
+    model_params = config[model_name]
+
+    for param, details in model_params.items():
+        param_type = details["type"]
+
+        if param_type == "list":
+            param_grid[param] = details["values"]
+        elif param_type == "int":
+            start, end = details["range"]
+            param_grid[param] = list(range(start, end + 1))
+        elif param_type == "float":
+            start, end, step = details["range"]
+            param_grid[param] = np.arange(start, end + step, step).tolist()
+        elif param_type == "bool":
+            param_grid[param] = [True, False]
+        else:
+            raise ValueError(f"Unsupported param type '{param_type}' for {param}")
+
+    return param_grid
+
+
+if __name__ == "__main__":
+    # Example Usage
+    config = load_yaml_config("./src/tuning/configs/modset1.yaml")
+    param_grid = generate_param_grid("AutoARIMA", config)
+    print(param_grid)

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -1,0 +1,7 @@
+import yaml
+
+
+def load_yaml_config(file_path):
+    """Load YAML configuration file from relative path"""
+    with open(file_path, "r") as file:
+        return yaml.safe_load(file)


### PR DESCRIPTION
- Added a `generate_param_grid(model, config` script that takes in the model name and config read in from a yaml config file specifying the model hyperparameters to be tuned, and returns the parameter grid to be used in tuning with `ForecastingGridSearchCV`
- Added a `src/utils` directory to add common utility functions, added `load_yaml_config` to load in a yaml file