### PR TITLE
Fixed hyperparam testing notebook bug

### DIFF
--- a/scripts/notebooks/3.09-ad-hyperparameter-tester.ipynb
+++ b/scripts/notebooks/3.09-ad-hyperparameter-tester.ipynb
@@ -10,8 +10,11 @@
     "from src.tuning.param_grid import generate_param_grid\n",
     "from pprint import pprint as pp\n",
     "\n",
+    "# Change below to the path of your config file\n",
     "config = load_yaml_config(\"../../src/tuning/configs/modset1.yaml\")\n",
+    "# Specify the model name you want to test params for (should match as labelled in the config)\n",
     "param_grid = generate_param_grid(\"ARIMA\", config)\n",
+    "\n",
     "pp(param_grid)"
    ]
   },
@@ -26,10 +29,20 @@
     "def simplify_dict(d):\n",
     "    for key, value in d.items():\n",
     "        if isinstance(value, list):\n",
-    "            d[key] = value[:1]  # Keep only the first element of the list (max length 1)\n",
-    "        # elif isinstance(value, int):\n",
-    "        # d[key] = value[:1]  # Keep only the first element of the list (max length 1)\n",
+    "            # Keep only the first element of the list (max length 1)\n",
+    "            d[key] = [value[0]]\t# If you want to test other params, change this to a different index\n",
     "    return d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To speed up testing we will only test one value for each parameter\n",
+    "param_grid = simplify_dict(param_grid)\n",
+    "param_grid"
    ]
   },
   {
@@ -42,24 +55,47 @@
     "from sktime.split import ExpandingSlidingWindowSplitter\n",
     "from sktime.performance_metrics.forecasting import MeanSquaredError\n",
     "from sktime.datasets import load_airline\n",
-    "from sktime.forecasting.arima import ARIMA\n",
+    "from sktime.forecasting.arima import ARIMA  # Change this to the model you want to test\n",
     "\n",
+    "# Not the actual data we will use, just a placeholder for simple testing\n",
     "y = load_airline()\n",
     "fh = [1, 2, 3, 4, 5, 6]\n",
     "cv = ExpandingSlidingWindowSplitter(\n",
     "    fh=fh, initial_window=12, step_length=12, max_expanding_window_length=24 * 12\n",
     ")\n",
+    "\n",
+    "# Specify the forecaster you generated the param grid for\n",
     "forecaster = ARIMA()\n",
+    "\n",
     "gscv = ForecastingGridSearchCV(\n",
     "    forecaster=forecaster,\n",
-    "    param_grid=simplify_dict(\n",
-    "        param_grid\n",
-    "    ),  # Simplify the dictionary so only first values are tested\n",
+    "    # Simplify the dictionary so only one set of values are tested\n",
+    "    param_grid=param_grid,\n",
     "    cv=cv,\n",
     "    scoring=MeanSquaredError(square_root=True),\n",
+    "\t# Raise errors so we can see what params are causing errors\n",
+    "    error_score=\"raise\",\n",
     ")\n",
     "gscv.fit(y)\n",
     "y_pred = gscv.predict(fh)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gscv.best_params_"
    ]
   }
  ],

--- a/scripts/notebooks/3.09-ad-hyperparameter-tester.ipynb
+++ b/scripts/notebooks/3.09-ad-hyperparameter-tester.ipynb
@@ -30,7 +30,9 @@
     "    for key, value in d.items():\n",
     "        if isinstance(value, list):\n",
     "            # Keep only the first element of the list (max length 1)\n",
-    "            d[key] = [value[0]]\t# If you want to test other params, change this to a different index\n",
+    "            d[key] = [\n",
+    "                value[0]\n",
+    "            ]  # If you want to test other params, change this to a different index\n",
     "    return d"
    ]
   },
@@ -73,7 +75,7 @@
     "    param_grid=param_grid,\n",
     "    cv=cv,\n",
     "    scoring=MeanSquaredError(square_root=True),\n",
-    "\t# Raise errors so we can see what params are causing errors\n",
+    "    # Raise errors so we can see what params are causing errors\n",
     "    error_score=\"raise\",\n",
     ")\n",
     "gscv.fit(y)\n",


### PR DESCRIPTION
The `simplify_dict` function was removing the param values from a list but for tuning the param_grid needs values to be in a list so this fixes it to keep the single values in a list (now no one should have any weird errors with testing their hyperparameters in the notebook `3.09-ad-hyperparameter-tester.ipynb`).