### PR TITLE
Add gap handling module for CGM time series segmentation

### DIFF
--- a/src/data/preprocessing/gap_handling.py
+++ b/src/data/preprocessing/gap_handling.py
@@ -240,10 +240,14 @@ def _detect_interval(df: pd.DataFrame) -> int:
         interval = get_most_common_time_interval(df)
         if interval > 0:
             return interval
-    except (ValueError, IndexError):
-        # get_most_common_time_interval can fail on irregular/sparse data;
-        # fall back to the default 5-min CGM interval below.
-        pass
+    except (ValueError, IndexError) as exc:
+        logger.warning(
+            "Failed to detect sampling interval for DataFrame with %d rows; "
+            "falling back to %d minutes. Error: %s",
+            len(df),
+            DEFAULT_FALLBACK_INTERVAL_MINS,
+            exc,
+        )
 
     return DEFAULT_FALLBACK_INTERVAL_MINS
 


### PR DESCRIPTION
### Description

Adds a gap handling utility for CGM time series data. TSFM's `ForecastDFDataset` creates sliding windows by row index — when CGM data has temporal gaps (sensor outages, sensor changes), windows silently span gaps and corrupt training. Analysis on Brown 2019 showed all 168 patients have gaps > 6 hours, with up to 60% of windows affected.

**Literature basis for this approach:**
- [GlucoBench](https://arxiv.org/html/2410.05780v1) — glucose forecasting benchmark that establishes gap handling norms for CGM data. Their preprocessing segments data at large gaps rather than blindly imputing across them.
- [CGM imputation research (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11686493/) — validates linear interpolation for short CGM gaps (< 30-45 min), but recommends against imputing longer gaps where sensor data is unreliable.
- Our codebase already has `generic_cleaning.erase_consecutive_nan_values()` (Aleppo's 6-hour consecutive NaN threshold) — same spirit, but operates at day-level granularity. This module generalizes the idea to arbitrary thresholds at the segment level.

**Key insight:** the problem is invisible unless you plot by timestamp. After `dropna()`, raw CGM data looks continuous by row index — a 644-day sensor gap between two readings appears as adjacent rows. Sliding windows built on row indices silently bridge these gaps.

**Strategy (all-or-nothing):**
1. Gaps ≤ 45 min → fully interpolated (linear, between two real anchor values only)
2. Gaps > 45 min → not interpolated at all, data is segmented at these boundaries
3. Segments shorter than context + prediction window (608 rows) → discarded

This module sits between the data loader and model pipeline:
- **Input:** `dict[patient_id, DataFrame]` (what every loader returns)
- **Output:** `dict[segment_id, DataFrame]` (same contract, continuous segments)

Opt-in module. No existing files modified.

**Files:**
- `src/data/preprocessing/gap_handling.py`
- `tests/data/data_cleaning/test_gap_handling.py`

### Testing

16 unit tests with hand-constructed data (every value traceable by hand):
- Small gap interpolation with exact value checks
- Small gap next to large gap (only small one filled, large untouched)
- Leading/trailing NaN dropped (no extrapolation via `limit_area="inside"`)
- Threshold boundary (9-row gap = 45 min → interpolated; 10-row gap → segmented)
- Edge cases: empty input, no DatetimeIndex, all-NaN patient, multi-patient independence, input not mutated
- Internal helpers: interval detection, NaN run detection

`pytest tests/data/data_cleaning/test_gap_handling.py -v` — 16/16 pass
