### PR TITLE
Add generic forecast comparison script

### DIFF
--- a/scripts/analysis/compare_forecasts.py
+++ b/scripts/analysis/compare_forecasts.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Generic model forecast comparison on holdout episodes.
+
+Compares any combination of models (zero-shot or fine-tuned) on midnight-
+anchored nocturnal episodes from the holdout set. Generates a grid plot
+with context + ground truth + all model forecasts overlaid.
+
+Model specs use the format: type:checkpoint:label
+  - type        required (toto, chronos2, ttm, sundial, ...)
+  - checkpoint  optional; empty = zero-shot
+  - label       optional; defaults to 'type' or 'type-ft'
+
+Usage:
+    python scripts/analysis/compare_forecasts.py \\
+        --model toto::Zero-shot \\
+        --model toto:path/to/ft/checkpoint:Fine-tuned \\
+        --model chronos2:path/to/ckpt:Chronos2
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.data.versioning.dataset_registry import DatasetRegistry
+from src.evaluation.episode_builders import (
+    DEFAULT_HOLDOUT_CONFIG_DIR,
+    build_patient_episodes,
+    get_holdout_patients,
+    select_episodes_stratified,
+)
+from src.models.factory import create_model_and_config
+
+CONTEXT_LENGTH = 512
+FORECAST_LENGTH = 72
+INTERVAL_MIN = 5
+DEFAULT_DATASET = "brown_2019"
+DEFAULT_EPISODES_PER_PATIENT = 4
+DEFAULT_SEED = 42
+
+COLOR_CYCLE = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+]
+
+
+def parse_model_spec(spec):
+    """Parse 'type:checkpoint:label' into (model_type, checkpoint, label)."""
+    parts = spec.split(":")
+    model_type = parts[0]
+    checkpoint = parts[1] if len(parts) > 1 and parts[1] else None
+    if len(parts) > 2 and parts[2]:
+        label = parts[2]
+    else:
+        label = model_type if not checkpoint else f"{model_type}-ft"
+    return model_type, checkpoint, label
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--model", action="append", required=True,
+        help="type:checkpoint:label  (repeatable; empty checkpoint = zero-shot)",
+    )
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--config-dir", default=DEFAULT_HOLDOUT_CONFIG_DIR)
+    parser.add_argument("--episodes-per-patient", type=int, default=DEFAULT_EPISODES_PER_PATIENT)
+    parser.add_argument("--patients", nargs="+", default=None,
+                        help="Holdout patient IDs to include (default: all holdout patients)")
+    parser.add_argument("--covariate-cols", nargs="+", default=None,
+                        help="Covariate columns to include in episodes (e.g. iob); "
+                             "fine-tuned checkpoints are also auto-detected")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--output-name", default=None)
+    args = parser.parse_args()
+
+    model_specs = [parse_model_spec(s) for s in args.model]
+
+    output_dir = args.output_dir or f"experiments/{args.dataset}_comparison"
+    os.makedirs(output_dir, exist_ok=True)
+
+    patients = (
+        args.patients
+        if args.patients is not None
+        else get_holdout_patients(args.dataset, args.config_dir)
+    )
+    print(f"Using {len(patients)} patients")
+
+    print("Loading holdout data...")
+    holdout_data = DatasetRegistry(holdout_config_dir=args.config_dir).load_holdout_data_only(args.dataset)
+
+    # Collect covariate cols needed by any fine-tuned model (auto-detected from config.json)
+    covariate_cols = set(args.covariate_cols or [])
+    for _, checkpoint, _ in model_specs:
+        if checkpoint:
+            config_path = os.path.join(checkpoint, "config.json")
+            if os.path.exists(config_path):
+                with open(config_path) as f:
+                    for col in (json.load(f).get("covariate_cols") or []):
+                        covariate_cols.add(col)
+    covariate_cols = list(covariate_cols) or None
+
+    print("Building episodes...")
+    episodes_by_patient = build_patient_episodes(
+        holdout_data, patients, CONTEXT_LENGTH, FORECAST_LENGTH, covariate_cols=covariate_cols,
+    )
+    selected = select_episodes_stratified(episodes_by_patient, args.episodes_per_patient, args.seed)
+    print(f"Selected {len(selected)} episodes ({args.episodes_per_patient}/patient, {len(episodes_by_patient)} patients)")
+
+    # Load models
+    models = []
+    for model_type, checkpoint, label in model_specs:
+        print(f"Loading {label} ({model_type}{', zero-shot' if not checkpoint else ''})...")
+        kwargs: dict = {"forecast_length": FORECAST_LENGTH}
+        if covariate_cols and model_type == "toto":
+            kwargs["covariate_cols"] = covariate_cols
+        model, _ = create_model_and_config(model_type, checkpoint, **kwargs)
+        models.append((model, label, model_type))
+
+    label_colors = {label: COLOR_CYCLE[i % len(COLOR_CYCLE)] for i, (_, label, _) in enumerate(models)}
+
+    # Generate forecasts
+    print("Generating forecasts...")
+    results = []
+    for i, ep in enumerate(selected):
+        ctx = ep["context_df"].copy().reset_index(names="datetime")
+        ctx["p_num"] = ep["patient_id"]
+        target = ep["target_bg"][:FORECAST_LENGTH]
+
+        try:
+            forecasts, rmses = {}, {}
+            for model, label, _ in models:
+                pred = model.predict(ctx)[:FORECAST_LENGTH]
+                forecasts[label] = pred
+                rmses[label] = np.sqrt(np.mean((pred[:len(target)] - target) ** 2))
+
+            results.append({
+                "patient_id": ep["patient_id"],
+                "anchor": str(ep["anchor"]),
+                "context_bg": ep["context_df"]["bg_mM"].values[-36:],
+                "target_bg": target,
+                "forecasts": forecasts,
+                "rmses": rmses,
+            })
+            rmse_str = "  ".join(f"{label}={rmses[label]:.2f}" for _, label, _ in models)
+            print(f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: {rmse_str}")
+
+        except Exception as e:
+            print(f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: FAILED - {e}")
+
+    print(f"\nSuccessful forecasts: {len(results)}/{len(selected)}")
+    if not results:
+        return
+
+    # Sort by first model RMSE (best to worst)
+    results.sort(key=lambda r: r["rmses"].get(model_specs[0][2], float("inf")))
+
+    # --- Plot ---
+    n_plots = len(results)
+    n_cols = 5
+    n_rows = max(1, (n_plots + n_cols - 1) // n_cols)
+
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 3.5 * n_rows), squeeze=False)
+    axes = axes.flatten()
+
+    time_ctx = np.arange(-36, 0) * INTERVAL_MIN / 60  # 3h context tail (hours)
+    time_fh = np.arange(FORECAST_LENGTH) * INTERVAL_MIN / 60  # forecast horizon (hours)
+
+    for idx, r in enumerate(results):
+        ax = axes[idx]
+        ax.plot(time_ctx, r["context_bg"], color="gray", linewidth=0.8, alpha=0.6)
+        ax.plot(time_fh, r["target_bg"], color="black", linewidth=1.5, label="Ground truth")
+        for _, label, _ in models:
+            ax.plot(time_fh, r["forecasts"][label], color=label_colors[label], linewidth=1.2, label=label)
+        ax.axhline(y=3.9, color="red", linewidth=0.5, linestyle="--", alpha=0.5)
+        ax.axvline(x=0, color="gray", linewidth=0.5, linestyle=":", alpha=0.5)
+        rmse_parts = [f"{label}:{r['rmses'][label]:.1f}" for _, label, _ in models]
+        ax.set_title(f"{r['patient_id']} | {' '.join(rmse_parts)}", fontsize=7)
+        ax.set_xlim(time_ctx[0], time_fh[-1])
+        ax.tick_params(labelsize=6)
+        if idx == 0:
+            ax.legend(fontsize=5, loc="upper right")
+
+    for idx in range(n_plots, len(axes)):
+        axes[idx].set_visible(False)
+
+    fig.suptitle(
+        f"Nocturnal Forecast Comparison — {', '.join(label for _, label, _ in models)}\n"
+        f"Black: ground truth | Red dashed: 3.9 mmol/L",
+        fontsize=10, y=1.01,
+    )
+    fig.tight_layout()
+
+    out_name = args.output_name or (
+        "comparison_"
+        + "_vs_".join(label.replace(" ", "-") for _, label, _ in models)
+        + f"_{n_plots}ep.png"
+    )
+    out_path = os.path.join(output_dir, out_name)
+    fig.savefig(out_path, dpi=200, bbox_inches="tight")
+    print(f"\nPlot saved to: {out_path}")
+    plt.close()
+
+    # Summary
+    labels = [label for _, label, _ in models]
+    print(f"\nSummary ({n_plots} episodes):")
+    for label in labels:
+        print(f"  {label}: mean RMSE = {np.mean([r['rmses'][label] for r in results]):.3f}")
+    for i in range(len(labels)):
+        for j in range(i + 1, len(labels)):
+            li, lj = labels[i], labels[j]
+            wins = sum(r["rmses"][lj] < r["rmses"][li] for r in results)
+            print(f"  {lj} wins over {li}: {wins}/{n_plots}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/compare_forecasts.py
+++ b/scripts/analysis/compare_forecasts.py
@@ -16,6 +16,7 @@ Usage:
         --model toto:path/to/ft/checkpoint:Fine-tuned \\
         --model chronos2:path/to/ckpt:Chronos2
 """
+
 import argparse
 import json
 import os
@@ -44,8 +45,16 @@ DEFAULT_EPISODES_PER_PATIENT = 4
 DEFAULT_SEED = 42
 
 COLOR_CYCLE = [
-    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
-    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
 ]
 
 
@@ -62,19 +71,33 @@ def parse_model_spec(spec):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
-        "--model", action="append", required=True,
+        "--model",
+        action="append",
+        required=True,
         help="type:checkpoint:label  (repeatable; empty checkpoint = zero-shot)",
     )
     parser.add_argument("--dataset", default=DEFAULT_DATASET)
     parser.add_argument("--config-dir", default=DEFAULT_HOLDOUT_CONFIG_DIR)
-    parser.add_argument("--episodes-per-patient", type=int, default=DEFAULT_EPISODES_PER_PATIENT)
-    parser.add_argument("--patients", nargs="+", default=None,
-                        help="Holdout patient IDs to include (default: all holdout patients)")
-    parser.add_argument("--covariate-cols", nargs="+", default=None,
-                        help="Covariate columns to include in episodes (e.g. iob); "
-                             "fine-tuned checkpoints are also auto-detected")
+    parser.add_argument(
+        "--episodes-per-patient", type=int, default=DEFAULT_EPISODES_PER_PATIENT
+    )
+    parser.add_argument(
+        "--patients",
+        nargs="+",
+        default=None,
+        help="Holdout patient IDs to include (default: all holdout patients)",
+    )
+    parser.add_argument(
+        "--covariate-cols",
+        nargs="+",
+        default=None,
+        help="Covariate columns to include in episodes (e.g. iob); "
+        "fine-tuned checkpoints are also auto-detected",
+    )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--output-dir", default=None)
     parser.add_argument("--output-name", default=None)
@@ -93,7 +116,9 @@ def main():
     print(f"Using {len(patients)} patients")
 
     print("Loading holdout data...")
-    holdout_data = DatasetRegistry(holdout_config_dir=args.config_dir).load_holdout_data_only(args.dataset)
+    holdout_data = DatasetRegistry(
+        holdout_config_dir=args.config_dir
+    ).load_holdout_data_only(args.dataset)
 
     # Collect covariate cols needed by any fine-tuned model (auto-detected from config.json)
     covariate_cols = set(args.covariate_cols or [])
@@ -102,28 +127,41 @@ def main():
             config_path = os.path.join(checkpoint, "config.json")
             if os.path.exists(config_path):
                 with open(config_path) as f:
-                    for col in (json.load(f).get("covariate_cols") or []):
+                    for col in json.load(f).get("covariate_cols") or []:
                         covariate_cols.add(col)
     covariate_cols = list(covariate_cols) or None
 
     print("Building episodes...")
     episodes_by_patient = build_patient_episodes(
-        holdout_data, patients, CONTEXT_LENGTH, FORECAST_LENGTH, covariate_cols=covariate_cols,
+        holdout_data,
+        patients,
+        CONTEXT_LENGTH,
+        FORECAST_LENGTH,
+        covariate_cols=covariate_cols,
     )
-    selected = select_episodes_stratified(episodes_by_patient, args.episodes_per_patient, args.seed)
-    print(f"Selected {len(selected)} episodes ({args.episodes_per_patient}/patient, {len(episodes_by_patient)} patients)")
+    selected = select_episodes_stratified(
+        episodes_by_patient, args.episodes_per_patient, args.seed
+    )
+    print(
+        f"Selected {len(selected)} episodes ({args.episodes_per_patient}/patient, {len(episodes_by_patient)} patients)"
+    )
 
     # Load models
     models = []
     for model_type, checkpoint, label in model_specs:
-        print(f"Loading {label} ({model_type}{', zero-shot' if not checkpoint else ''})...")
+        print(
+            f"Loading {label} ({model_type}{', zero-shot' if not checkpoint else ''})..."
+        )
         kwargs: dict = {"forecast_length": FORECAST_LENGTH}
         if covariate_cols and model_type == "toto":
             kwargs["covariate_cols"] = covariate_cols
         model, _ = create_model_and_config(model_type, checkpoint, **kwargs)
         models.append((model, label, model_type))
 
-    label_colors = {label: COLOR_CYCLE[i % len(COLOR_CYCLE)] for i, (_, label, _) in enumerate(models)}
+    label_colors = {
+        label: COLOR_CYCLE[i % len(COLOR_CYCLE)]
+        for i, (_, label, _) in enumerate(models)
+    }
 
     # Generate forecasts
     print("Generating forecasts...")
@@ -138,21 +176,29 @@ def main():
             for model, label, _ in models:
                 pred = model.predict(ctx)[:FORECAST_LENGTH]
                 forecasts[label] = pred
-                rmses[label] = np.sqrt(np.mean((pred[:len(target)] - target) ** 2))
+                rmses[label] = np.sqrt(np.mean((pred[: len(target)] - target) ** 2))
 
-            results.append({
-                "patient_id": ep["patient_id"],
-                "anchor": str(ep["anchor"]),
-                "context_bg": ep["context_df"]["bg_mM"].values[-36:],
-                "target_bg": target,
-                "forecasts": forecasts,
-                "rmses": rmses,
-            })
-            rmse_str = "  ".join(f"{label}={rmses[label]:.2f}" for _, label, _ in models)
-            print(f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: {rmse_str}")
+            results.append(
+                {
+                    "patient_id": ep["patient_id"],
+                    "anchor": str(ep["anchor"]),
+                    "context_bg": ep["context_df"]["bg_mM"].values[-36:],
+                    "target_bg": target,
+                    "forecasts": forecasts,
+                    "rmses": rmses,
+                }
+            )
+            rmse_str = "  ".join(
+                f"{label}={rmses[label]:.2f}" for _, label, _ in models
+            )
+            print(
+                f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: {rmse_str}"
+            )
 
         except Exception as e:
-            print(f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: FAILED - {e}")
+            print(
+                f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: FAILED - {e}"
+            )
 
     print(f"\nSuccessful forecasts: {len(results)}/{len(selected)}")
     if not results:
@@ -166,7 +212,9 @@ def main():
     n_cols = 5
     n_rows = max(1, (n_plots + n_cols - 1) // n_cols)
 
-    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 3.5 * n_rows), squeeze=False)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(5 * n_cols, 3.5 * n_rows), squeeze=False
+    )
     axes = axes.flatten()
 
     time_ctx = np.arange(-36, 0) * INTERVAL_MIN / 60  # 3h context tail (hours)
@@ -175,9 +223,17 @@ def main():
     for idx, r in enumerate(results):
         ax = axes[idx]
         ax.plot(time_ctx, r["context_bg"], color="gray", linewidth=0.8, alpha=0.6)
-        ax.plot(time_fh, r["target_bg"], color="black", linewidth=1.5, label="Ground truth")
+        ax.plot(
+            time_fh, r["target_bg"], color="black", linewidth=1.5, label="Ground truth"
+        )
         for _, label, _ in models:
-            ax.plot(time_fh, r["forecasts"][label], color=label_colors[label], linewidth=1.2, label=label)
+            ax.plot(
+                time_fh,
+                r["forecasts"][label],
+                color=label_colors[label],
+                linewidth=1.2,
+                label=label,
+            )
         ax.axhline(y=3.9, color="red", linewidth=0.5, linestyle="--", alpha=0.5)
         ax.axvline(x=0, color="gray", linewidth=0.5, linestyle=":", alpha=0.5)
         rmse_parts = [f"{label}:{r['rmses'][label]:.1f}" for _, label, _ in models]
@@ -193,7 +249,8 @@ def main():
     fig.suptitle(
         f"Nocturnal Forecast Comparison — {', '.join(label for _, label, _ in models)}\n"
         f"Black: ground truth | Red dashed: 3.9 mmol/L",
-        fontsize=10, y=1.01,
+        fontsize=10,
+        y=1.01,
     )
     fig.tight_layout()
 
@@ -211,7 +268,9 @@ def main():
     labels = [label for _, label, _ in models]
     print(f"\nSummary ({n_plots} episodes):")
     for label in labels:
-        print(f"  {label}: mean RMSE = {np.mean([r['rmses'][label] for r in results]):.3f}")
+        print(
+            f"  {label}: mean RMSE = {np.mean([r['rmses'][label] for r in results]):.3f}"
+        )
     for i in range(len(labels)):
         for j in range(i + 1, len(labels)):
             li, lj = labels[i], labels[j]

--- a/scripts/analysis/compare_forecasts.py
+++ b/scripts/analysis/compare_forecasts.py
@@ -1,48 +1,35 @@
 #!/usr/bin/env python3
-"""Generic model forecast comparison on holdout episodes.
+"""Compare nocturnal forecast results from pre-computed JSON files.
 
-Compares any combination of models (zero-shot or fine-tuned) on midnight-
-anchored nocturnal episodes from the holdout set. Generates a grid plot
-with context + ground truth + all model forecasts overlaid.
-
-Model specs use the format: type:checkpoint:label
-  - type        required (toto, chronos2, ttm, sundial, ...)
-  - checkpoint  optional; empty = zero-shot
-  - label       optional; defaults to 'type' or 'type-ft'
+Reads N nocturnal_results.json files (produced by nocturnal_hypo_eval.py),
+matches episodes by (patient_id, anchor), and generates comparison plots +
+summary statistics. No model imports — runs in any Python env with
+numpy + matplotlib.
 
 Usage:
-    python scripts/analysis/compare_forecasts.py \\
-        --model toto::Zero-shot \\
-        --model toto:path/to/ft/checkpoint:Fine-tuned \\
-        --model chronos2:path/to/ckpt:Chronos2
+    python scripts/analysis/compare_forecasts.py \
+        --results experiments/.../chronos2/nocturnal_results.json "Chronos2-ft" \
+                  experiments/.../toto/nocturnal_results.json "Toto-zs" \
+        --output-dir experiments/comparisons/chronos2_vs_toto/
+
+    # Subset to specific patients
+    python scripts/analysis/compare_forecasts.py \
+        --results path/a.json "Model A" path/b.json "Model B" \
+        --patients bro_92 bro_57 \
+        --max-episodes 20
 """
 
 import argparse
+import csv
 import json
 import os
 import sys
-from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from src.data.versioning.dataset_registry import DatasetRegistry
-from src.evaluation.episode_builders import (
-    DEFAULT_HOLDOUT_CONFIG_DIR,
-    build_patient_episodes,
-    get_holdout_patients,
-    select_episodes_stratified,
-)
-from src.models.factory import create_model_and_config
-
-CONTEXT_LENGTH = 512
-FORECAST_LENGTH = 72
 INTERVAL_MIN = 5
-DEFAULT_DATASET = "brown_2019"
-DEFAULT_EPISODES_PER_PATIENT = 4
-DEFAULT_SEED = 42
+CONTEXT_TAIL_STEPS = 36  # 3h of context shown in plots
 
 COLOR_CYCLE = [
     "#1f77b4",
@@ -58,16 +45,21 @@ COLOR_CYCLE = [
 ]
 
 
-def parse_model_spec(spec):
-    """Parse 'type:checkpoint:label' into (model_type, checkpoint, label)."""
-    parts = spec.split(":")
-    model_type = parts[0]
-    checkpoint = parts[1] if len(parts) > 1 and parts[1] else None
-    if len(parts) > 2 and parts[2]:
-        label = parts[2]
-    else:
-        label = model_type if not checkpoint else f"{model_type}-ft"
-    return model_type, checkpoint, label
+def parse_results_args(results_args: list) -> list:
+    """Parse --results args as alternating path label pairs.
+
+    Accepts: path1 label1 path2 label2 ...
+    Labels are required — every path must be followed by a label string.
+    """
+    if len(results_args) % 2 != 0:
+        print(
+            "Error: --results requires pairs of <path> <label>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return [
+        (results_args[i], results_args[i + 1]) for i in range(0, len(results_args), 2)
+    ]
 
 
 def main():
@@ -75,158 +67,135 @@ def main():
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--model",
-        action="append",
+        "--results",
+        nargs="+",
         required=True,
-        help="type:checkpoint:label  (repeatable; empty checkpoint = zero-shot)",
-    )
-    parser.add_argument("--dataset", default=DEFAULT_DATASET)
-    parser.add_argument("--config-dir", default=DEFAULT_HOLDOUT_CONFIG_DIR)
-    parser.add_argument(
-        "--episodes-per-patient", type=int, default=DEFAULT_EPISODES_PER_PATIENT
+        help="Alternating pairs of: path/to/nocturnal_results.json label",
     )
     parser.add_argument(
         "--patients",
         nargs="+",
         default=None,
-        help="Holdout patient IDs to include (default: all holdout patients)",
+        help="Filter to these patient IDs (default: all common patients)",
     )
     parser.add_argument(
-        "--covariate-cols",
-        nargs="+",
+        "--max-episodes",
+        type=int,
         default=None,
-        help="Covariate columns to include in episodes (e.g. iob); "
-        "fine-tuned checkpoints are also auto-detected",
+        help="Max episodes to plot (default: all matched episodes)",
     )
-    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
-    parser.add_argument("--output-dir", default=None)
+    parser.add_argument(
+        "--sort-by",
+        choices=["rmse", "divergence", "patient"],
+        default="rmse",
+        help="Sort episodes by: rmse (first model), divergence (max pred diff), patient",
+    )
+    parser.add_argument("--output-dir", default="experiments/comparisons")
     parser.add_argument("--output-name", default=None)
     args = parser.parse_args()
 
-    model_specs = [parse_model_spec(s) for s in args.model]
+    entries = parse_results_args(args.results)
 
-    output_dir = args.output_dir or f"experiments/{args.dataset}_comparison"
-    os.makedirs(output_dir, exist_ok=True)
-
-    patients = (
-        args.patients
-        if args.patients is not None
-        else get_holdout_patients(args.dataset, args.config_dir)
-    )
-    print(f"Using {len(patients)} patients")
-
-    print("Loading holdout data...")
-    holdout_data = DatasetRegistry(
-        holdout_config_dir=args.config_dir
-    ).load_holdout_data_only(args.dataset)
-
-    # Collect covariate cols needed by any fine-tuned model (auto-detected from config.json)
-    covariate_cols = set(args.covariate_cols or [])
-    for _, checkpoint, _ in model_specs:
-        if checkpoint:
-            config_path = os.path.join(checkpoint, "config.json")
-            if os.path.exists(config_path):
-                with open(config_path) as f:
-                    for col in json.load(f).get("covariate_cols") or []:
-                        covariate_cols.add(col)
-    covariate_cols = list(covariate_cols) or None
-
-    print("Building episodes...")
-    episodes_by_patient = build_patient_episodes(
-        holdout_data,
-        patients,
-        CONTEXT_LENGTH,
-        FORECAST_LENGTH,
-        covariate_cols=covariate_cols,
-    )
-    selected = select_episodes_stratified(
-        episodes_by_patient, args.episodes_per_patient, args.seed
-    )
-    print(
-        f"Selected {len(selected)} episodes ({args.episodes_per_patient}/patient, {len(episodes_by_patient)} patients)"
-    )
-
-    # Load models
+    # Load and index all result files (keep only the index, not the full data)
     models = []
-    for model_type, checkpoint, label in model_specs:
-        print(
-            f"Loading {label} ({model_type}{', zero-shot' if not checkpoint else ''})..."
-        )
-        kwargs: dict = {"forecast_length": FORECAST_LENGTH}
-        if covariate_cols and model_type == "toto":
-            kwargs["covariate_cols"] = covariate_cols
-        model, _ = create_model_and_config(model_type, checkpoint, **kwargs)
-        models.append((model, label, model_type))
+    for path, label in entries:
+        with open(path) as f:
+            data = json.load(f)
+        n_episodes = len(data["per_episode"])
+        index = {(ep["patient_id"], ep["anchor"]): ep for ep in data["per_episode"]}
+        models.append({"label": label, "index": index})
+        print(f"Loaded {label}: {n_episodes} episodes from {path}")
 
+    # Find common episodes across all models
+    common_keys = set(models[0]["index"].keys())
+    for m in models[1:]:
+        common_keys &= set(m["index"].keys())
+
+    if args.patients:
+        patient_set = set(args.patients)
+        common_keys = {k for k in common_keys if k[0] in patient_set}
+
+    print(f"Common episodes: {len(common_keys)}")
+    if not common_keys:
+        print(
+            "No common episodes found. Check that result files cover the same patients/dataset."
+        )
+        sys.exit(1)
+
+    # Build matched results
+    labels = [m["label"] for m in models]
+    matched = []
+    for key in common_keys:
+        patient_id, anchor = key
+        ep0 = models[0]["index"][key]
+        forecast_len = len(ep0["pred"])
+
+        entry = {
+            "patient_id": patient_id,
+            "anchor": anchor,
+            "target_bg": np.array(ep0["target_bg"][:forecast_len]),
+            "context_bg": np.array(ep0["context_bg"][-CONTEXT_TAIL_STEPS:]),
+            "forecasts": {},
+            "rmses": {},
+        }
+        for m in models:
+            ep = m["index"][key]
+            entry["forecasts"][m["label"]] = np.array(ep["pred"][:forecast_len])
+            entry["rmses"][m["label"]] = float(ep["rmse"])
+        matched.append(entry)
+
+    # Free index memory now that matching is done
+    del models
+
+    # Sort
+    if args.sort_by == "rmse":
+        matched.sort(key=lambda r: r["rmses"].get(labels[0], float("inf")))
+    elif args.sort_by == "divergence" and len(labels) >= 2:
+        # Pre-compute divergence once per episode to avoid repeated work during sort
+        for r in matched:
+            preds = list(r["forecasts"].values())
+            r["_divergence"] = max(
+                np.sqrt(np.mean((preds[i] - preds[j]) ** 2))
+                for i in range(len(preds))
+                for j in range(i + 1, len(preds))
+            )
+        matched.sort(key=lambda r: r["_divergence"], reverse=True)
+    elif args.sort_by == "patient":
+        matched.sort(key=lambda r: (r["patient_id"], r["anchor"]))
+
+    if args.max_episodes:
+        matched = matched[: args.max_episodes]
+
+    n_plots = len(matched)
+    print(f"Plotting {n_plots} episodes")
+
+    # --- Output setup ---
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # --- Plot grid ---
     label_colors = {
-        label: COLOR_CYCLE[i % len(COLOR_CYCLE)]
-        for i, (_, label, _) in enumerate(models)
+        label: COLOR_CYCLE[i % len(COLOR_CYCLE)] for i, label in enumerate(labels)
     }
 
-    # Generate forecasts
-    print("Generating forecasts...")
-    results = []
-    for i, ep in enumerate(selected):
-        ctx = ep["context_df"].copy().reset_index(names="datetime")
-        ctx["p_num"] = ep["patient_id"]
-        target = ep["target_bg"][:FORECAST_LENGTH]
-
-        try:
-            forecasts, rmses = {}, {}
-            for model, label, _ in models:
-                pred = model.predict(ctx)[:FORECAST_LENGTH]
-                forecasts[label] = pred
-                rmses[label] = np.sqrt(np.mean((pred[: len(target)] - target) ** 2))
-
-            results.append(
-                {
-                    "patient_id": ep["patient_id"],
-                    "anchor": str(ep["anchor"]),
-                    "context_bg": ep["context_df"]["bg_mM"].values[-36:],
-                    "target_bg": target,
-                    "forecasts": forecasts,
-                    "rmses": rmses,
-                }
-            )
-            rmse_str = "  ".join(
-                f"{label}={rmses[label]:.2f}" for _, label, _ in models
-            )
-            print(
-                f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: {rmse_str}"
-            )
-
-        except Exception as e:
-            print(
-                f"  [{i+1}/{len(selected)}] {ep['patient_id']} {ep['anchor']}: FAILED - {e}"
-            )
-
-    print(f"\nSuccessful forecasts: {len(results)}/{len(selected)}")
-    if not results:
-        return
-
-    # Sort by first model RMSE (best to worst)
-    results.sort(key=lambda r: r["rmses"].get(model_specs[0][2], float("inf")))
-
-    # --- Plot ---
-    n_plots = len(results)
-    n_cols = 5
+    n_cols = min(5, n_plots)
     n_rows = max(1, (n_plots + n_cols - 1) // n_cols)
 
     fig, axes = plt.subplots(
         n_rows, n_cols, figsize=(5 * n_cols, 3.5 * n_rows), squeeze=False
     )
-    axes = axes.flatten()
+    axes_flat = axes.flatten()
 
-    time_ctx = np.arange(-36, 0) * INTERVAL_MIN / 60  # 3h context tail (hours)
-    time_fh = np.arange(FORECAST_LENGTH) * INTERVAL_MIN / 60  # forecast horizon (hours)
+    forecast_len = len(matched[0]["target_bg"])
+    time_ctx = np.arange(-CONTEXT_TAIL_STEPS, 0) * INTERVAL_MIN / 60
+    time_fh = np.arange(forecast_len) * INTERVAL_MIN / 60
 
-    for idx, r in enumerate(results):
-        ax = axes[idx]
+    for idx, r in enumerate(matched):
+        ax = axes_flat[idx]
         ax.plot(time_ctx, r["context_bg"], color="gray", linewidth=0.8, alpha=0.6)
         ax.plot(
             time_fh, r["target_bg"], color="black", linewidth=1.5, label="Ground truth"
         )
-        for _, label, _ in models:
+        for label in labels:
             ax.plot(
                 time_fh,
                 r["forecasts"][label],
@@ -236,19 +205,19 @@ def main():
             )
         ax.axhline(y=3.9, color="red", linewidth=0.5, linestyle="--", alpha=0.5)
         ax.axvline(x=0, color="gray", linewidth=0.5, linestyle=":", alpha=0.5)
-        rmse_parts = [f"{label}:{r['rmses'][label]:.1f}" for _, label, _ in models]
+        rmse_parts = [f"{label}:{r['rmses'][label]:.1f}" for label in labels]
         ax.set_title(f"{r['patient_id']} | {' '.join(rmse_parts)}", fontsize=7)
         ax.set_xlim(time_ctx[0], time_fh[-1])
         ax.tick_params(labelsize=6)
         if idx == 0:
             ax.legend(fontsize=5, loc="upper right")
 
-    for idx in range(n_plots, len(axes)):
-        axes[idx].set_visible(False)
+    for idx in range(n_plots, len(axes_flat)):
+        axes_flat[idx].set_visible(False)
 
     fig.suptitle(
-        f"Nocturnal Forecast Comparison — {', '.join(label for _, label, _ in models)}\n"
-        f"Black: ground truth | Red dashed: 3.9 mmol/L",
+        f"Nocturnal Forecast Comparison — {', '.join(labels)}\n"
+        f"Black: ground truth | Red dashed: 3.9 mmol/L | {n_plots} episodes",
         fontsize=10,
         y=1.01,
     )
@@ -256,26 +225,44 @@ def main():
 
     out_name = args.output_name or (
         "comparison_"
-        + "_vs_".join(label.replace(" ", "-") for _, label, _ in models)
+        + "_vs_".join(lbl.replace(" ", "-") for lbl in labels)
         + f"_{n_plots}ep.png"
     )
-    out_path = os.path.join(output_dir, out_name)
+    out_path = os.path.join(args.output_dir, out_name)
     fig.savefig(out_path, dpi=200, bbox_inches="tight")
-    print(f"\nPlot saved to: {out_path}")
+    print(f"Plot saved to: {out_path}")
     plt.close()
 
-    # Summary
-    labels = [label for _, label, _ in models]
+    # --- RMSE summary CSV ---
+    csv_path = os.path.join(args.output_dir, out_name.replace(".png", "_rmse.csv"))
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["patient_id", "anchor"] + [f"rmse_{lbl}" for lbl in labels])
+        for r in matched:
+            writer.writerow(
+                [r["patient_id"], r["anchor"]]
+                + [f"{r['rmses'][lbl]:.4f}" for lbl in labels]
+            )
+    print(f"RMSE CSV saved to: {csv_path}")
+
+    # --- Summary stats ---
     print(f"\nSummary ({n_plots} episodes):")
     for label in labels:
+        rmses = [r["rmses"][label] for r in matched]
         print(
-            f"  {label}: mean RMSE = {np.mean([r['rmses'][label] for r in results]):.3f}"
+            f"  {label}: mean RMSE = {np.mean(rmses):.3f}, median = {np.median(rmses):.3f}"
         )
-    for i in range(len(labels)):
-        for j in range(i + 1, len(labels)):
-            li, lj = labels[i], labels[j]
-            wins = sum(r["rmses"][lj] < r["rmses"][li] for r in results)
-            print(f"  {lj} wins over {li}: {wins}/{n_plots}")
+
+    if len(labels) >= 2:
+        for i in range(len(labels)):
+            for j in range(i + 1, len(labels)):
+                li, lj = labels[i], labels[j]
+                wins_j = sum(r["rmses"][lj] < r["rmses"][li] for r in matched)
+                wins_i = sum(r["rmses"][li] < r["rmses"][lj] for r in matched)
+                ties = n_plots - wins_i - wins_j
+                print(
+                    f"  {lj} wins {wins_j}/{n_plots}, {li} wins {wins_i}/{n_plots}, ties {ties}"
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/experiments/nocturnal_hypo_eval.py
+++ b/scripts/experiments/nocturnal_hypo_eval.py
@@ -154,6 +154,8 @@ def save_experiment_config(
         cmd_parts.extend(["--checkpoint", args.checkpoint])
     if args.model_config:
         cmd_parts.extend(["--model-config", args.model_config])
+    if args.patients:
+        cmd_parts.extend(["--patients"] + args.patients)
 
     config = {
         "evaluation_type": "nocturnal_hypoglycemia",
@@ -167,6 +169,7 @@ def save_experiment_config(
             "cuda_device": args.cuda_device,
             "model_config": args.model_config,
             "output_dir": args.output_dir,
+            "patients": args.patients,
         },
         "model_config": model_config,
         "environment": {
@@ -251,6 +254,13 @@ def parse_arguments() -> argparse.Namespace:
         nargs="*",
         default=None,
         help="Covariate column names (e.g., iob cob)",
+    )
+    parser.add_argument(
+        "--patients",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Subset of patient IDs to evaluate (default: all holdout patients)",
     )
     parser.add_argument(
         "--cuda-device",
@@ -338,8 +348,11 @@ def main():
     holdout_data = registry.load_holdout_data_only(args.dataset)
 
     patient_col = get_patient_column(holdout_data)
+    if args.patients:
+        holdout_data = holdout_data[holdout_data[patient_col].isin(args.patients)]
+        logger.info(f"Filtered to {len(args.patients)} patients: {args.patients}")
     patients = holdout_data[patient_col].unique()
-    logger.info(f"Holdout patients: {list(patients)}")
+    logger.info(f"Evaluating patients: {list(patients)}")
     logger.info(f"Total samples: {len(holdout_data):,}")
 
     # Save experiment configuration

--- a/src/evaluation/episode_builders.py
+++ b/src/evaluation/episode_builders.py
@@ -31,6 +31,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+# Default holdout config directory (can be overridden by callers)
+DEFAULT_HOLDOUT_CONFIG_DIR = "configs/data/holdout_10pct"
+
 # Default sampling interval for CGM data
 SAMPLING_INTERVAL_MINUTES = 5
 
@@ -194,3 +197,84 @@ def build_midnight_episodes(
         )
 
     return episodes, skip_stats
+
+
+# ---------------------------------------------------------------------------
+# Holdout loading helpers
+# ---------------------------------------------------------------------------
+
+
+def get_holdout_patients(
+    dataset: str,
+    config_dir: str = DEFAULT_HOLDOUT_CONFIG_DIR,
+) -> List[str]:
+    """Return the holdout patient list for a dataset."""
+    from src.data.versioning.dataset_registry import DatasetRegistry
+
+    hc = DatasetRegistry(holdout_config_dir=config_dir).get_holdout_config(dataset)
+    if hc is None or hc.patient_config is None:
+        raise ValueError(f"No patient holdout config found for {dataset}")
+    return hc.patient_config.holdout_patients
+
+
+# ---------------------------------------------------------------------------
+# Multi-patient episode building
+# ---------------------------------------------------------------------------
+
+
+def build_patient_episodes(
+    holdout_data: pd.DataFrame,
+    patients: List[str],
+    context_length: int,
+    forecast_length: int,
+    covariate_cols: Optional[List[str]] = None,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Build midnight episodes grouped by patient.
+
+    Args:
+        holdout_data: Combined holdout DataFrame (all patients).
+        patients: Patient IDs to include.
+        context_length: Number of context steps per episode.
+        forecast_length: Number of forecast steps per episode.
+        covariate_cols: Optional covariate columns to include.
+
+    Returns:
+        Dict mapping patient_id -> list of episode dicts (each with 'patient_id' added).
+    """
+    patient_col = "p_num" if "p_num" in holdout_data.columns else "id"
+    episodes_by_patient: Dict[str, List[Dict[str, Any]]] = {}
+
+    for pid in patients:
+        pdf = holdout_data[holdout_data[patient_col] == pid]
+        if pdf.empty:
+            continue
+        if "datetime" in pdf.columns:
+            pdf = pdf.set_index(pd.to_datetime(pdf["datetime"]))
+        episodes, _ = build_midnight_episodes(
+            pdf, context_length, forecast_length, covariate_cols=covariate_cols,
+        )
+        valid = [ep | {"patient_id": pid} for ep in episodes if len(ep["target_bg"]) >= forecast_length]
+        if valid:
+            episodes_by_patient[pid] = valid
+
+    return episodes_by_patient
+
+
+def select_episodes_stratified(
+    episodes_by_patient: Dict[str, List[Dict[str, Any]]],
+    per_patient: int,
+    seed: int = 42,
+) -> List[Dict[str, Any]]:
+    """Stratified episode sampling: pick `per_patient` random episodes from each patient.
+
+    Sorting patients alphabetically before sampling ensures reproducibility
+    across calls with the same seed, regardless of dict insertion order.
+    """
+    rng = np.random.RandomState(seed)
+    selected = []
+    for pid in sorted(episodes_by_patient.keys()):
+        eps = episodes_by_patient[pid]
+        n = min(per_patient, len(eps))
+        for i in sorted(rng.choice(len(eps), n, replace=False)):
+            selected.append(eps[i])
+    return selected

--- a/src/evaluation/episode_builders.py
+++ b/src/evaluation/episode_builders.py
@@ -251,9 +251,16 @@ def build_patient_episodes(
         if "datetime" in pdf.columns:
             pdf = pdf.set_index(pd.to_datetime(pdf["datetime"]))
         episodes, _ = build_midnight_episodes(
-            pdf, context_length, forecast_length, covariate_cols=covariate_cols,
+            pdf,
+            context_length,
+            forecast_length,
+            covariate_cols=covariate_cols,
         )
-        valid = [ep | {"patient_id": pid} for ep in episodes if len(ep["target_bg"]) >= forecast_length]
+        valid = [
+            ep | {"patient_id": pid}
+            for ep in episodes
+            if len(ep["target_bg"]) >= forecast_length
+        ]
         if valid:
             episodes_by_patient[pid] = valid
 


### PR DESCRIPTION
### Summary

- **Add `compare_forecasts.py`** — env-agnostic script that reads N `nocturnal_results.json` files (from `nocturnal_hypo_eval.py`), matches episodes by (patient_id, anchor), and generates grid comparison plots + per-episode RMSE CSV + win rate summary. No model imports needed — runs in any venv with numpy + matplotlib, solving the cross-env problem (e.g. chronos2 vs toto can't coexist in one Python process).

- **Add `--patients` to `nocturnal_hypo_eval.py`** — run eval on a subset of holdout patients for quick comparisons (e.g. `--patients bro_92 bro_57`). Patient list is persisted to `experiment_config.json` and the reproducibility command.

- **Add episode builder utilities** (`episode_builders.py`) — `get_holdout_patients()`, `build_patient_episodes()`, `select_episodes_stratified()` for building and sampling midnight-anchored episodes from holdout data.

### Workflow

```bash
# 1. Eval each model in its own venv
srun --partition=HI --gres=gpu:1 ... \
    .venvs/toto/bin/python scripts/experiments/nocturnal_hypo_eval.py \
    --model toto --dataset brown_2019 --patients bro_92 bro_57

srun --partition=HI --gres=gpu:1 ... \
    .venvs/chronos2/bin/python scripts/experiments/nocturnal_hypo_eval.py \
    --model chronos2 --checkpoint path/to/ckpt --patients bro_92 bro_57

# 2. Compare (any venv, no GPU)
python scripts/analysis/compare_forecasts.py \
    --results path/to/toto/nocturnal_results.json "Toto-zs" \
             path/to/chronos2/nocturnal_results.json "Chronos2-ft" \
    --max-episodes 20 --sort-by divergence
```