### PR TITLE
Add Toto finetuning

### DIFF
--- a/configs/models/toto/00_bg_only.yaml
+++ b/configs/models/toto/00_bg_only.yaml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Toto — Blood Glucose Only Baseline
+# =============================================================================
+# Fine-tunes Toto on BG (bg_mM) as the sole input — no covariates.
+# This is the BG-only baseline for comparison against covariate models.
+#
+# Toto trains by gradient steps (max_steps) via PyTorch Lightning.
+# Default 3000 steps is a production run. Use max_steps=100 for smoke tests.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/00_bg_only.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96  # 8 hours at 5-min intervals
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+# Step-based training (PyTorch Lightning).
+max_steps: 10000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+# Batch sizes
+train_batch_size: 4
+val_batch_size: 1
+
+# BG only — no covariates
+covariate_cols: []

--- a/configs/models/toto/01_bg_iob.yaml
+++ b/configs/models/toto/01_bg_iob.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB Only  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Isolates insulin-on-board (IOB) as the sole covariate.
+# Compare against 00 (BG-only) to measure IOB contribution.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/01_bg_iob.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 15000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob]

--- a/configs/models/toto/02_bg_iob_ia.yaml
+++ b/configs/models/toto/02_bg_iob_ia.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Adds insulin_availability alongside IOB.
+# Compare against 01 (IOB only) to check if availability signal helps.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/02_bg_iob_ia.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]

--- a/configs/models/toto/03_bg_iob_ia_high_lr.yaml
+++ b/configs/models/toto/03_bg_iob_ia_high_lr.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=5e-4  |  ctx=512
+# =============================================================================
+# Same covariates as 02, but 5× higher learning rate.
+# Compare against 02 to check LR sensitivity.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/03_bg_iob_ia_high_lr.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 5.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]

--- a/configs/models/toto/04_bg_iob_short_ctx.yaml
+++ b/configs/models/toto/04_bg_iob_short_ctx.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=1e-4  |  ctx=288
+# =============================================================================
+# Same covariates as 02, but shorter context window (288 vs 512).
+# Compare against 02 to check context length sensitivity.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/04_bg_iob_short_ctx.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 288
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]

--- a/configs/models/toto/05_bg_iob_cob.yaml
+++ b/configs/models/toto/05_bg_iob_cob.yaml
@@ -1,0 +1,33 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Adds carbs-on-board (COB) alongside IOB.
+# Baseline carb addition — compare against 01 (IOB only).
+# brown_2019 excluded (no meal data in DCLP3 export).
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/05_bg_iob_cob.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]

--- a/configs/models/toto/06_bg_full_features.yaml
+++ b/configs/models/toto/06_bg_full_features.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + COB + insulin_avail + carb_avail  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Kitchen-sink: all four covariates.
+# Compare against 05 (IOB + COB only) to measure availability signal value.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/06_bg_full_features.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob, insulin_availability, carb_availability]

--- a/configs/models/toto/07_bg_iob_cob_high_lr.yaml
+++ b/configs/models/toto/07_bg_iob_cob_high_lr.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=5e-4  |  ctx=512
+# =============================================================================
+# Same covariates as 05, but 5× higher learning rate.
+# Compare against 05 to check LR sensitivity with carb covariates.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/07_bg_iob_cob_high_lr.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 5.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]

--- a/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
+++ b/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=1e-4  |  ctx=288
+# =============================================================================
+# Same covariates as 05, but shorter context window (288 vs 512).
+# Compare against 05 to check context length sensitivity with carbs.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/08_bg_iob_cob_short_ctx.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 288
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]

--- a/configs/models/toto/bg_iob_cob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_cob_smoke_test.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG + IOB + COB, 100 steps)
+# =============================================================================
+# Fast end-to-end validation of the carbs covariate path.
+# Exercises the COB + IOB exogenous-variable pipeline.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_iob_cob_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]

--- a/configs/models/toto/bg_iob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_smoke_test.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG + IOB, 100 steps)
+# =============================================================================
+# Fast end-to-end validation of the covariate path.
+# Exercises the IOB exogenous-variable pipeline.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_iob_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob]

--- a/configs/models/toto/bg_only_smoke_test.yaml
+++ b/configs/models/toto/bg_only_smoke_test.yaml
@@ -1,0 +1,35 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG only, 100 steps)
+# =============================================================================
+# Fast end-to-end validation. max_steps=100 keeps it under a few minutes.
+# Use this to verify the Toto fine-tuning pipeline works before launching
+# real sweeps.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_only_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+# 100 steps = fast smoke test. Use 3000 for production.
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+# BG only — no covariates
+covariate_cols: []

--- a/notes/toto_hyperparameter.md
+++ b/notes/toto_hyperparameter.md
@@ -1,0 +1,321 @@
+# Toto Hyperparameter Sweep — Training Commands
+
+All commands assume you are in the repo root.
+`CONFIG_DIR` is set to `holdout_10pct` throughout; change if needed.
+Step 7 (resume training) is skipped via `SKIP_STEPS="7"` on every run.
+
+---
+
+## Environment Setup (run once per session)
+
+**1. Activate conda base environment:**
+```bash
+conda activate env-in-conda
+```
+
+**2. Create or activate the Toto model venv** (first run creates `.venvs/toto` and installs deps; subsequent runs just activate it):
+```bash
+source scripts/setup_model_env.sh toto
+```
+
+> The training workflow script (`run_holdout_generic_workflow.sh`) will auto-activate `.venvs/toto` once it exists. The `source scripts/setup_model_env.sh toto` step above is only needed to create it the first time, or if you want to run Python directly outside the workflow script.
+
+---
+
+## Smoke Tests (run these first)
+
+These use 100-step configs for fast end-to-end validation (<5 min each).
+
+**BG-only path** — verifies the basic Toto fine-tuning pipeline:
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_only_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+**CGM+Insulin path** — exercises `bg_iob_smoke_test.yaml` end-to-end:
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_iob_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+**CGM+Insulin+Carbs path** — exercises `bg_iob_cob_smoke_test.yaml` end-to-end (carb feature engineering path):
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_iob_cob_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## BG-Only Baseline
+
+Datasets: `aleppo_2017 brown_2019 lynch_2022 tamborlane_2008`
+
+### 00 — BG only  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/00_bg_only.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## CGM + Insulin Runs
+
+Datasets: `aleppo_2017 brown_2019 lynch_2022`
+
+### 01 — IOB only  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/01_bg_iob.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 02 — IOB + insulin_availability  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/02_bg_iob_ia.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 03 — IOB + insulin_availability  |  lr=5e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/03_bg_iob_ia_high_lr.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 04 — IOB + insulin_availability  |  lr=1e-4  |  ctx=288
+```bash
+CUDA_VISIBLE_DEVICES=1 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/04_bg_iob_short_ctx.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## CGM + Insulin + Carbs Runs
+
+Datasets: `aleppo_2017 lynch_2022`
+(brown_2019 excluded — no meal data in DCLP3 export)
+
+### 05 — IOB + COB  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/05_bg_iob_cob.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 06 — IOB + COB + insulin_availability + carb_availability  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/06_bg_full_features.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 07 — IOB + COB  |  lr=5e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/07_bg_iob_cob_high_lr.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 08 — IOB + COB  |  lr=1e-4  |  ctx=288
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/08_bg_iob_cob_short_ctx.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## Comparison Matrix
+
+| Config | Covariates                          | LR   | Context | Datasets           | Key comparison                |
+| ------ | ----------------------------------- | ---- | ------- | ------------------ | ----------------------------- |
+| 00     | none                                | 1e-4 | 512     | ale, bro, lyn, tam | BG-only baseline              |
+| **01** | iob                                 | 1e-4 | 512     | ale, bro, lyn      | isolates IOB vs 00            |
+| **02** | iob, insulin_avail                  | 1e-4 | 512     | ale, bro, lyn      | +availability vs 01           |
+| **03** | iob, insulin_avail                  | 5e-4 | 512     | ale, bro, lyn      | higher LR vs 02               |
+| **04** | iob, insulin_avail                  | 1e-4 | 288     | ale, bro, lyn      | shorter ctx vs 02             |
+| **05** | iob, cob                            | 1e-4 | 512     | ale, lyn           | baseline carb addition vs 01  |
+| **06** | iob, cob, insulin_avail, carb_avail | 1e-4 | 512     | ale, lyn           | kitchen-sink vs 05            |
+| **07** | iob, cob                            | 5e-4 | 512     | ale, lyn           | higher LR vs 05               |
+| **08** | iob, cob                            | 1e-4 | 288     | ale, lyn           | shorter ctx vs 05             |
+
+---
+
+## Nocturnal Evaluation
+
+After training completes, run nocturnal evaluation (midnight-anchored 8-hour overnight forecasting) on each holdout dataset. Replace `<CHECKPOINT>` with the actual `model.pt` path from the training output.
+
+> **Tip**: Each training run prints the checkpoint path at the end. It lives at
+> `trained_models/artifacts/toto/<timestamp>_RID<run_id>_holdout_workflow/model.pt`
+
+### 00 — BG only (zero-shot baseline: omit `--checkpoint`)
+
+Checkpoint: `trained_models/artifacts/toto/2026-03-18_06:21_RID20260318_062105_1962383_holdout_workflow/model.pt`
+
+```bash
+# Zero-shot (no checkpoint)
+for ds in aleppo_2017 brown_2019 lynch_2022 tamborlane_2008; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/00_bg_only.yaml \
+    --context-length 512 --forecast-length 96 \
+    --cuda-device 0
+done
+
+# Fine-tuned
+for ds in aleppo_2017 brown_2019 lynch_2022 tamborlane_2008; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/00_bg_only.yaml \
+    --context-length 512 --forecast-length 96 \
+    --cuda-device 0 \
+    --checkpoint trained_models/artifacts/toto/2026-03-18_06:21_RID20260318_062105_1962383_holdout_workflow/model.pt
+done
+```
+
+### 01 — IOB only
+
+Checkpoint: `trained_models/artifacts/toto/2026-03-18_20:06_RID20260318_200624_2050916_holdout_workflow/model.pt`
+
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/01_bg_iob.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob \
+    --cuda-device 0 \
+    --checkpoint trained_models/artifacts/toto/2026-03-18_20:06_RID20260318_200624_2050916_holdout_workflow/model.pt
+done
+```
+
+### 02 — IOB + insulin_availability
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/02_bg_iob_ia.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 03 — IOB + insulin_availability  |  lr=5e-4
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/03_bg_iob_ia_high_lr.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 04 — IOB + insulin_availability  |  ctx=288
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/04_bg_iob_short_ctx.yaml \
+    --context-length 288 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 05 — IOB + COB
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/05_bg_iob_cob.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 06 — IOB + COB + insulin_availability + carb_availability
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/06_bg_full_features.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob insulin_availability carb_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 07 — IOB + COB  |  lr=5e-4
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/07_bg_iob_cob_high_lr.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 08 — IOB + COB  |  ctx=288
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/08_bg_iob_cob_short_ctx.yaml \
+    --context-length 288 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+---
+
+## Notes
+
+- **Model**: `Datadog/Toto-Open-Base-1.0` — downloaded automatically on first run.
+- **Training**: Toto uses PyTorch Lightning with `max_steps` (gradient steps, not epochs). Default 3000 steps. Smoke tests use 100 steps.
+- **LR schedule**: Warmup (200 steps) → stable peak (1000 steps) → cosine decay (1000 steps) down to `min_lr`.
+- **Covariates**: Passed as exogenous variables (past-only) via `covariate_cols` in the YAML config. Toto encodes these alongside BG as multivariate input.
+- **Step 7 skipped**: Resume training is skipped (`SKIP_STEPS="7"`) on all runs since we want clean single-phase training results.
+- **Forecast length**: 96 steps (8 hours at 5-min intervals) to match Chronos-2 sweep.
+- **Results**: Written to `trained_models/artifacts/toto/<timestamp>_RID<run_id>_holdout_workflow/`.
+
+## Environment Setup
+
+The `.venvs/toto` venv required the following fixes for Blackwell GPUs:
+
+```bash
+# PyTorch 2.10 for sm_120 (Blackwell) support
+pip install --index-url https://download.pytorch.org/whl/cu128 torch==2.10.0+cu128
+
+# setuptools <82 (82+ removed pkg_resources which toto-ts imports)
+pip install "setuptools<82"
+```
+
+Additionally, the installed toto package's `helpers.py` was patched to skip `pd.infer_freq()` when
+`freq` is already present in the HuggingFace dataset (our CGM data has gaps that cause
+`pd.infer_freq` to return `None`). The patch is at:
+
+```
+.venvs/toto/lib/python3.12/site-packages/toto/data/util/helpers.py  (line ~213)
+```
+
+Changed unconditional `hf_dataset.map(lambda: {"freq": pd.infer_freq(...)})` to:
+```python
+if "freq" not in hf_dataset.column_names:
+    hf_dataset = hf_dataset.map(lambda item: {"freq": pd.infer_freq(...)})
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ timesfm = [
 tide = [
     "autogluon.timeseries==1.5.0",
 ]
+toto = [
+    "toto-ts",
+]
 
 [tool.setuptools.packages.find]
 include = ["src*"]

--- a/scripts/examples/example_holdout_generic_workflow.py
+++ b/scripts/examples/example_holdout_generic_workflow.py
@@ -422,15 +422,21 @@ class ModelFactory:
         try:
             from src.models.toto import TotoForecaster, TotoConfig
 
-            toto_config = TotoConfig(
-                context_length=config.context_length,
-                forecast_length=config.forecast_length,
-                batch_size=config.batch_size,
-                num_epochs=config.num_epochs,
-                lr=config.learning_rate,
-                use_cpu=config.use_cpu,
-                **config.extra_config,
-            )
+            # Build kwargs from extra_config, letting YAML values take
+            # precedence for Toto-specific params (lr, max_steps, etc.)
+            toto_kwargs = dict(config.extra_config) if config.extra_config else {}
+
+            # Set explicit args only if not already provided by YAML
+            toto_kwargs.setdefault("context_length", config.context_length)
+            toto_kwargs.setdefault("forecast_length", config.forecast_length)
+            toto_kwargs.setdefault("batch_size", config.batch_size)
+            if config.num_epochs is not None:
+                toto_kwargs.setdefault("num_epochs", config.num_epochs)
+            if config.learning_rate is not None and "lr" not in toto_kwargs:
+                toto_kwargs["lr"] = config.learning_rate
+            toto_kwargs.setdefault("use_cpu", config.use_cpu)
+
+            toto_config = TotoConfig(**toto_kwargs)
 
             return TotoForecaster(toto_config, distributed_config=distributed_config)
         except ImportError as e:

--- a/scripts/examples/example_holdout_generic_workflow.py
+++ b/scripts/examples/example_holdout_generic_workflow.py
@@ -171,6 +171,7 @@ class ModelFactory:
             "timesfm": "google/timesfm-2.0-500m-pytorch",
             "timegrad": "",  # Trains from scratch, no pretrained path
             "tide": "",  # Trains from scratch, no pretrained path
+            "toto": "Datadog/Toto-Open-Base-1.0",
         }
         return defaults.get(model_type, "")
 
@@ -207,10 +208,12 @@ class ModelFactory:
             return ModelFactory._create_timegrad_model(config, distributed_config)
         elif model_type == "tide":
             return ModelFactory._create_tide_model(config, distributed_config)
+        elif model_type == "toto":
+            return ModelFactory._create_toto_model(config, distributed_config)
         else:
             raise ValueError(
                 f"Unsupported model type: {model_type}. "
-                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide"
+                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide, toto"
             )
 
     @staticmethod
@@ -408,6 +411,34 @@ class ModelFactory:
             raise ImportError(
                 f"TiDE model not available. Install with: "
                 f"pip install 'nocturnal-hypo-gly-prob-forecast[tide]': {e}"
+            )
+
+    @staticmethod
+    def _create_toto_model(
+        config: GenericModelConfig,
+        distributed_config: Optional[DistributedConfig] = None,
+    ):
+        """Create a Toto model instance."""
+        try:
+            from src.models.toto import TotoForecaster, TotoConfig
+
+            toto_config = TotoConfig(
+                context_length=config.context_length,
+                forecast_length=config.forecast_length,
+                batch_size=config.batch_size,
+                num_epochs=config.num_epochs,
+                lr=config.learning_rate,
+                use_cpu=config.use_cpu,
+                **config.extra_config,
+            )
+
+            return TotoForecaster(
+                toto_config, distributed_config=distributed_config
+            )
+        except ImportError as e:
+            raise ImportError(
+                f"Toto model not available. Install with: "
+                f"source scripts/setup_model_env.sh toto\n{e}"
             )
 
     @staticmethod
@@ -674,10 +705,14 @@ class ModelFactory:
             from src.models.tide import TiDEForecaster
 
             return TiDEForecaster.load(model_path)
+        elif model_type_lower == "toto":
+            from src.models.toto import TotoForecaster
+
+            return TotoForecaster.load(model_path)
         else:
             raise ValueError(
                 f"Unsupported model type for loading: {model_type}. "
-                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide"
+                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide, toto"
             )
 
 
@@ -833,7 +868,7 @@ def _generate_forecasts(
             logger.info(f"  Context data shape: {context_data.shape}")
 
             # Generate predictions — model only sees context, predicts forward
-            if zero_shot:
+            if zero_shot and hasattr(model, "predict_zero_shot"):
                 predictions_raw = model.predict_zero_shot(context_data)
             else:
                 predictions_raw = model.predict(context_data)
@@ -1901,7 +1936,7 @@ stored in separate subdirectories for comparison.
         "--model-type",
         type=str,
         default="ttm",
-        choices=["ttm", "chronos", "chronos2", "moment", "timesfm", "timegrad", "tide"],
+        choices=["ttm", "chronos", "chronos2", "moment", "timesfm", "timegrad", "tide", "toto"],
         help="Type of model to use (default: ttm)",
     )
     parser.add_argument(

--- a/scripts/examples/example_holdout_generic_workflow.py
+++ b/scripts/examples/example_holdout_generic_workflow.py
@@ -432,9 +432,7 @@ class ModelFactory:
                 **config.extra_config,
             )
 
-            return TotoForecaster(
-                toto_config, distributed_config=distributed_config
-            )
+            return TotoForecaster(toto_config, distributed_config=distributed_config)
         except ImportError as e:
             raise ImportError(
                 f"Toto model not available. Install with: "
@@ -1927,7 +1925,16 @@ stored in separate subdirectories for comparison.
         "--model-type",
         type=str,
         default="ttm",
-        choices=["ttm", "chronos", "chronos2", "moment", "timesfm", "timegrad", "tide", "toto"],
+        choices=[
+            "ttm",
+            "chronos",
+            "chronos2",
+            "moment",
+            "timesfm",
+            "timegrad",
+            "tide",
+            "toto",
+        ],
         help="Type of model to use (default: ttm)",
     )
     parser.add_argument(

--- a/scripts/examples/run_holdout_generic_workflow.sh
+++ b/scripts/examples/run_holdout_generic_workflow.sh
@@ -58,6 +58,7 @@ RUN_ID="${RUN_ID:-$(date +%Y%m%d_%H%M%S)_$$}"
 : ${CONFIG_DIR:="configs/data/holdout_10pct"}
 : ${OUTPUT_BASE_DIR:="trained_models/artifacts/${MODEL_TYPE}/$(date +%Y-%m-%d_%H:%M)_RID${RUN_ID}_holdout_workflow"}
 : ${SKIP_TRAINING:="true"}
+: ${SKIP_STEPS:=""}      # Space-separated step numbers to skip (e.g., SKIP_STEPS="7" or SKIP_STEPS="4 7")
 : ${EPOCHS:=""}          # Leave empty to use YAML config value; set to override (e.g., EPOCHS=10)
 : ${BATCH_SIZE:=""}      # Leave empty to use YAML config value; set to override (e.g., BATCH_SIZE=4096)
 : ${MODEL_TYPE:="ttm"}  # Model type: ttm, chronos, moment, etc.
@@ -80,6 +81,7 @@ echo "  Datasets: $DATASETS"
 echo "  Config dir: $CONFIG_DIR"
 echo "  Output base dir: $OUTPUT_BASE_DIR"
 echo "  Skip training: $SKIP_TRAINING"
+echo "  Skip steps: ${SKIP_STEPS:-none}"
 echo "  Epochs: ${EPOCHS:-from YAML or default}"
 echo "  Batch size: ${BATCH_SIZE:-from YAML or default}"
 echo "  Model config: ${MODEL_CONFIG:-None (using defaults)}"
@@ -199,6 +201,9 @@ fi
 if [ "$SKIP_TRAINING" = "true" ]; then
     CMD="$CMD --skip-training"
 fi
+if [ -n "$SKIP_STEPS" ]; then
+    CMD="$CMD --skip-steps $SKIP_STEPS"
+fi
 
 echo "Running combined workflow..."
 # Pretty print for logs (display only)
@@ -218,10 +223,12 @@ if [ -n "$MODEL_CONFIG" ]; then
     echo "    --model-config $MODEL_CONFIG \\"
 fi
 if [ "$SKIP_TRAINING" = "true" ]; then
-    echo "    --skip-training"
-else
-    echo ""
+    echo "    --skip-training \\"
 fi
+if [ -n "$SKIP_STEPS" ]; then
+    echo "    --skip-steps $SKIP_STEPS \\"
+fi
+echo ""
 echo ""
 
 # Create log filename with run ID (matches SLURM pattern with job ID)

--- a/scripts/experiments/nocturnal_hypo_eval.py
+++ b/scripts/experiments/nocturnal_hypo_eval.py
@@ -200,7 +200,16 @@ def parse_arguments() -> argparse.Namespace:
         "--model",
         type=str,
         default="ttm",
-        choices=["sundial", "ttm", "chronos2", "moirai", "timegrad", "timesfm", "tide", "toto"],
+        choices=[
+            "sundial",
+            "ttm",
+            "chronos2",
+            "moirai",
+            "timegrad",
+            "timesfm",
+            "tide",
+            "toto",
+        ],
         help="Model type to use for evaluation",
     )
     parser.add_argument(

--- a/scripts/experiments/nocturnal_hypo_eval.py
+++ b/scripts/experiments/nocturnal_hypo_eval.py
@@ -200,7 +200,7 @@ def parse_arguments() -> argparse.Namespace:
         "--model",
         type=str,
         default="ttm",
-        choices=["sundial", "ttm", "chronos2", "moirai", "timegrad", "timesfm", "tide"],
+        choices=["sundial", "ttm", "chronos2", "moirai", "timegrad", "timesfm", "tide", "toto"],
         help="Model type to use for evaluation",
     )
     parser.add_argument(

--- a/scripts/experiments/validate_predict_batch.py
+++ b/scripts/experiments/validate_predict_batch.py
@@ -346,7 +346,16 @@ def parse_arguments() -> argparse.Namespace:
         "--model",
         type=str,
         default="ttm",
-        choices=["sundial", "ttm", "chronos2", "moirai", "timegrad", "timesfm", "tide"],
+        choices=[
+            "sundial",
+            "ttm",
+            "chronos2",
+            "moirai",
+            "timegrad",
+            "timesfm",
+            "tide",
+            "toto",
+        ],
     )
     parser.add_argument(
         "--model-config", type=str, default=None, help="Path to model config YAML file"

--- a/scripts/training/slurm/toto_eval.sh
+++ b/scripts/training/slurm/toto_eval.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#SBATCH --job-name=toto_eval
+#SBATCH --output=logs/toto_eval_%j.out
+#SBATCH --error=logs/toto_eval_%j.err
+#SBATCH --time=2:00:00
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32GB
+#SBATCH --gres=gpu:1
+#SBATCH --partition=HI
+
+# Evaluate Toto zero-shot on nocturnal forecasting task.
+#
+# Usage:
+#   sbatch scripts/training/slurm/toto_eval.sh
+#
+# Override defaults:
+#   DATASET=tamborlane_2008 sbatch scripts/training/slurm/toto_eval.sh
+
+: ${DATASET:="brown_2019"}
+: ${CONFIG_DIR:="configs/data/holdout_10pct"}
+
+if [ -n "$SLURM_SUBMIT_DIR" ]; then
+    PROJECT_ROOT="$SLURM_SUBMIT_DIR"
+else
+    PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+fi
+cd "$PROJECT_ROOT" || exit 1
+
+mkdir -p logs
+
+echo "========================================="
+echo "Toto Nocturnal Evaluation (SLURM)"
+echo "========================================="
+echo "Job ID:      $SLURM_JOB_ID"
+echo "Node:        $SLURM_NODELIST"
+echo "Dataset:     $DATASET"
+echo "Config Dir:  $CONFIG_DIR"
+echo "Started:     $(date)"
+echo "========================================="
+
+source ".venvs/toto/bin/activate"
+echo "Python: $(which python)"
+
+nvidia-smi --query-gpu=index,name,memory.total --format=csv
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+echo ""
+echo "Running nocturnal_hypo_eval.py..."
+echo ""
+
+python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$DATASET" \
+    --config-dir "$CONFIG_DIR" \
+    --context-length 512 \
+    --forecast-length 72 \
+    --cuda-device 0
+
+exit_code=$?
+
+echo ""
+echo "========================================="
+echo "Completed: $(date)"
+echo "Exit code: $exit_code"
+echo "========================================="
+
+exit $exit_code

--- a/src/models/base/base_model.py
+++ b/src/models/base/base_model.py
@@ -147,7 +147,10 @@ class ModelConfig:
         Raises:
             TypeError: If config_dict contains keys that are not valid attributes.
         """
-        return cls(**config_dict)
+        d = dict(config_dict)
+        if "training_backend" in d and isinstance(d["training_backend"], str):
+            d["training_backend"] = TrainingBackend(d["training_backend"])
+        return cls(**d)
 
 
 @dataclass
@@ -236,6 +239,11 @@ class BaseTimeSeriesFoundationModel(ABC):
     - Model saving/loading with metadata
     - Evaluation and metrics computation
     """
+
+    # Subclasses override this to point at their config class so that
+    # the base load() can deserialize config.json correctly without
+    # each model needing its own load() override.
+    config_class: type = ModelConfig
 
     def __init__(
         self,
@@ -551,7 +559,7 @@ class BaseTimeSeriesFoundationModel(ABC):
             if os.path.exists(config_path):
                 with open(config_path, "r") as f:
                     config_dict = json.load(f)
-                config = ModelConfig.from_dict(config_dict)
+                config = cls.config_class.from_dict(config_dict)
             else:
                 raise ValueError(f"No config found at {config_path}")
 

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -12,6 +12,7 @@ _MODEL_MODULES: Dict[str, str] = {
     "tsmixer": "src.models.tsmixer",
     "timesfm": "src.models.timesfm",
     "timegrad": "src.models.timegrad",
+    "toto": "src.models.toto",
     "moirai": "src.models.moirai",
     "moment": "src.models.moment",
 }

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -61,6 +61,8 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
       metadata are external pipeline concerns, not model-internal state.
     """
 
+    config_class = Chronos2Config
+
     def __init__(
         self,
         config: Chronos2Config,
@@ -298,39 +300,6 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------
-
-    # Why override load(): The base class load() at base_model.py:553
-    # hardcodes `ModelConfig.from_dict(config_dict)`, which crashes when
-    # the saved config.json contains Chronos-2-specific fields (covariate_cols,
-    # fine_tune_steps, etc.) that ModelConfig doesn't accept. We override to
-    # deserialize as Chronos2Config instead, then delegate to super().load()
-    # with the pre-built config so it skips the ModelConfig.from_dict() path.
-    @classmethod
-    def load(cls, model_path: str, config=None) -> "Chronos2Forecaster":
-        """Load a saved Chronos-2 model.
-
-        Overrides base class to deserialize config as Chronos2Config
-        (not ModelConfig), preserving Chronos-2-specific fields like
-        covariate_cols, fine_tune_steps, etc.
-        """
-        if config is None:
-            config_path = os.path.join(model_path, "config.json")
-            if os.path.exists(config_path):
-                with open(config_path) as f:
-                    config_dict = json.load(f)
-                # Convert serialized enum strings back to enum values.
-                # ModelConfig.to_dict() saves enums as strings (e.g.
-                # TrainingBackend.CUSTOM -> "custom"), but dataclass
-                # constructors don't auto-coerce strings back to enums.
-                if "training_backend" in config_dict:
-                    config_dict["training_backend"] = TrainingBackend(
-                        config_dict["training_backend"]
-                    )
-                config = Chronos2Config(**config_dict)
-            else:
-                raise ValueError(f"No config found at {config_path}")
-        # Pass pre-deserialized config to parent — skips ModelConfig.from_dict()
-        return super().load(model_path, config=config)
 
     def _save_checkpoint(self, output_dir: str) -> None:
         """Save predictor path reference.

--- a/src/models/factory.py
+++ b/src/models/factory.py
@@ -293,6 +293,8 @@ def create_model_and_config(
 
             if "batch_size" in kwargs:
                 config.batch_size = kwargs["batch_size"]
+            if "covariate_cols" in kwargs:
+                config.covariate_cols = kwargs["covariate_cols"]
             if "forecast_length" in kwargs:
                 requested = kwargs["forecast_length"]
                 if requested <= config.forecast_length:

--- a/src/models/factory.py
+++ b/src/models/factory.py
@@ -306,10 +306,9 @@ def create_model_and_config(
                         f"({config.forecast_length}). Using saved value."
                     )
         else:
-            config = TotoConfig(
-                forecast_length=kwargs.get("forecast_length", 72),
-                num_samples=kwargs.get("num_samples", 20),
-            )
+            toto_kwargs = {**kwargs}
+            toto_kwargs.setdefault("forecast_length", 72)
+            config = TotoConfig(**toto_kwargs)
             model = TotoForecaster(config)
         return model, config
 

--- a/src/models/factory.py
+++ b/src/models/factory.py
@@ -284,6 +284,35 @@ def create_model_and_config(
             model = TimeGradForecaster(config)
         return model, config
 
+    elif model_type == "toto":
+        from src.models.toto import TotoForecaster, TotoConfig
+
+        if checkpoint:
+            model = TotoForecaster.load(checkpoint)
+            config = model.config
+
+            if "batch_size" in kwargs:
+                config.batch_size = kwargs["batch_size"]
+            if "forecast_length" in kwargs:
+                requested = kwargs["forecast_length"]
+                if requested <= config.forecast_length:
+                    logger.info(
+                        f"Overriding forecast_length: {config.forecast_length} -> {requested}"
+                    )
+                    config.forecast_length = requested
+                else:
+                    logger.warning(
+                        f"Cannot increase forecast_length beyond trained value "
+                        f"({config.forecast_length}). Using saved value."
+                    )
+        else:
+            config = TotoConfig(
+                forecast_length=kwargs.get("forecast_length", 72),
+                num_samples=kwargs.get("num_samples", 20),
+            )
+            model = TotoForecaster(config)
+        return model, config
+
     elif model_type == "timesfm":
         from src.models.timesfm import TimesFMForecaster, TimesFMConfig
 
@@ -371,5 +400,5 @@ def create_model_and_config(
     else:
         raise ValueError(
             f"Unknown model type: {model_type}. "
-            f"Available: sundial, ttm, chronos, chronos2, moirai, timegrad, timesfm, tide"
+            f"Available: sundial, ttm, chronos, chronos2, toto, moirai, timegrad, timesfm, tide"
         )

--- a/src/models/tide/model.py
+++ b/src/models/tide/model.py
@@ -49,6 +49,8 @@ class TiDEForecaster(BaseTimeSeriesFoundationModel):
     - Uses TiDE-specific hyperparameters (encoder/decoder dims, MeanScaler)
     """
 
+    config_class = TiDEConfig
+
     def __init__(
         self,
         config: TiDEConfig,
@@ -261,28 +263,6 @@ class TiDEForecaster(BaseTimeSeriesFoundationModel):
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------
-
-    @classmethod
-    def load(cls, model_path: str, config=None) -> "TiDEForecaster":
-        """Load a saved TiDE model.
-
-        Overrides base class to deserialize config as TiDEConfig
-        (not ModelConfig), preserving TiDE-specific fields like
-        encoder_hidden_dim, scaling, covariate_cols, etc.
-        """
-        if config is None:
-            config_path = os.path.join(model_path, "config.json")
-            if os.path.exists(config_path):
-                with open(config_path) as f:
-                    config_dict = json.load(f)
-                if "training_backend" in config_dict:
-                    config_dict["training_backend"] = TrainingBackend(
-                        config_dict["training_backend"]
-                    )
-                config = TiDEConfig(**config_dict)
-            else:
-                raise ValueError(f"No config found at {config_path}")
-        return super().load(model_path, config=config)
 
     def _save_checkpoint(self, output_dir: str) -> None:
         """Save predictor path reference.

--- a/src/models/toto/__init__.py
+++ b/src/models/toto/__init__.py
@@ -1,0 +1,6 @@
+"""Toto model implementation."""
+
+from .config import TotoConfig
+from .model import TotoForecaster
+
+__all__ = ["TotoConfig", "TotoForecaster"]

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -6,10 +6,29 @@ from src.models.base import ModelConfig, TrainingBackend
 
 
 class TotoConfig(ModelConfig):
-    """Configuration class for Toto models."""
+    """Configuration class for Toto models.
+
+    Attributes:
+        num_samples: Number of forecast samples (None = single mean prediction).
+        samples_per_batch: Samples per batch during inference.
+        max_steps: Number of fine-tuning gradient steps.
+        lr: Learning rate for fine-tuning.
+        min_lr: Minimum learning rate after decay.
+        warmup_steps: LR warmup steps.
+        stable_steps: Steps at peak LR before decay.
+        decay_steps: Steps for LR decay.
+        train_batch_size: Training batch size.
+        val_batch_size: Validation batch size.
+        val_prediction_len: Prediction length for validation loss.
+    """
 
     def __init__(self, **kwargs):
-        toto_specific_params = {"num_samples", "samples_per_batch"}
+        toto_specific_params = {
+            "num_samples", "samples_per_batch",
+            "max_steps", "num_epochs", "lr", "min_lr",
+            "warmup_steps", "stable_steps", "decay_steps",
+            "train_batch_size", "val_batch_size", "val_prediction_len",
+        }
 
         # Filter out Toto-specific params from kwargs for parent class
         base_kwargs = {
@@ -22,5 +41,21 @@ class TotoConfig(ModelConfig):
         # Set Toto-specific defaults
         self.model_type = "toto"
         self.training_backend = TrainingBackend.CUSTOM
-        self.num_samples = kwargs.get("num_samples", 20)
+
+        # Inference
+        self.num_samples = kwargs.get("num_samples", None)
         self.samples_per_batch = kwargs.get("samples_per_batch", 20)
+
+        # Training — supports both max_steps and num_epochs.
+        # num_epochs is used by the generic workflow; max_steps is Toto-native.
+        # If neither is explicitly set, default to max_steps=3000.
+        self.num_epochs = kwargs.get("num_epochs", None)
+        self.max_steps = kwargs.get("max_steps", None if self.num_epochs else 3000)
+        self.lr = kwargs.get("lr", 1e-4)
+        self.min_lr = kwargs.get("min_lr", 1e-5)
+        self.warmup_steps = kwargs.get("warmup_steps", 200)
+        self.stable_steps = kwargs.get("stable_steps", 1000)
+        self.decay_steps = kwargs.get("decay_steps", 1000)
+        self.train_batch_size = kwargs.get("train_batch_size", 4)
+        self.val_batch_size = kwargs.get("val_batch_size", 1)
+        self.val_prediction_len = kwargs.get("val_prediction_len", 96)

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -24,17 +24,23 @@ class TotoConfig(ModelConfig):
 
     def __init__(self, **kwargs):
         toto_specific_params = {
-            "num_samples", "samples_per_batch",
-            "max_steps", "num_epochs", "lr", "min_lr",
-            "warmup_steps", "stable_steps", "decay_steps",
-            "train_batch_size", "val_batch_size", "val_prediction_len",
+            "num_samples",
+            "samples_per_batch",
+            "max_steps",
+            "num_epochs",
+            "lr",
+            "min_lr",
+            "warmup_steps",
+            "stable_steps",
+            "decay_steps",
+            "train_batch_size",
+            "val_batch_size",
+            "val_prediction_len",
             "covariate_cols",
         }
 
         # Filter out Toto-specific params from kwargs for parent class
-        base_kwargs = {
-            k: v for k, v in kwargs.items() if k not in toto_specific_params
-        }
+        base_kwargs = {k: v for k, v in kwargs.items() if k not in toto_specific_params}
 
         # Call parent with filtered kwargs
         super().__init__(**base_kwargs)

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -1,0 +1,26 @@
+"""
+Toto configuration classes.
+"""
+
+from src.models.base import ModelConfig, TrainingBackend
+
+
+class TotoConfig(ModelConfig):
+    """Configuration class for Toto models."""
+
+    def __init__(self, **kwargs):
+        toto_specific_params = {"num_samples", "samples_per_batch"}
+
+        # Filter out Toto-specific params from kwargs for parent class
+        base_kwargs = {
+            k: v for k, v in kwargs.items() if k not in toto_specific_params
+        }
+
+        # Call parent with filtered kwargs
+        super().__init__(**base_kwargs)
+
+        # Set Toto-specific defaults
+        self.model_type = "toto"
+        self.training_backend = TrainingBackend.CUSTOM
+        self.num_samples = kwargs.get("num_samples", 20)
+        self.samples_per_batch = kwargs.get("samples_per_batch", 20)

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -28,6 +28,7 @@ class TotoConfig(ModelConfig):
             "max_steps", "num_epochs", "lr", "min_lr",
             "warmup_steps", "stable_steps", "decay_steps",
             "train_batch_size", "val_batch_size", "val_prediction_len",
+            "covariate_cols",
         }
 
         # Filter out Toto-specific params from kwargs for parent class
@@ -59,3 +60,6 @@ class TotoConfig(ModelConfig):
         self.train_batch_size = kwargs.get("train_batch_size", 4)
         self.val_batch_size = kwargs.get("val_batch_size", 1)
         self.val_prediction_len = kwargs.get("val_prediction_len", 96)
+
+        # Covariates — past-only exogenous variables (e.g., ["iob"])
+        self.covariate_cols = kwargs.get("covariate_cols", None) or []

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -2,7 +2,9 @@
 Toto model implementation using the base TSFM framework.
 """
 
+import json
 import logging
+import os
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -47,6 +49,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
 
         self.model = toto.model
         self.forecaster = _TotoForecaster(self.model)
+        self._patch_size = getattr(self.model.patch_embed, "patch_size", 16)
 
         info_print(f"Toto model initialized on {self.device}")
 
@@ -114,21 +117,264 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
                 samples_per_batch=self.config.samples_per_batch,
             )
 
-        return forecast.median.cpu().numpy()[0]
+        # When num_samples is None, forecast has .mean only (single forward pass).
+        # When num_samples is set, use .median across sampled trajectories.
+        if self.config.num_samples is None:
+            result = forecast.mean.cpu().numpy()
+        else:
+            result = forecast.median.cpu().numpy()
+        return result.flatten()
 
-    # Stub implementations for abstract methods (zero-shot only for now)
+    def _dataframe_to_hf_dataset(self, train_data: pd.DataFrame):
+        """Convert a flat DataFrame to HuggingFace Dataset format for Toto.
+
+        Each patient's contiguous BG series becomes one row in the HF dataset
+        with 'timestamp' and 'target' fields.
+
+        Args:
+            train_data: DataFrame with 'bg_mM', 'datetime', and 'p_num' columns.
+
+        Returns:
+            HuggingFace Dataset with timestamp/target fields per series.
+        """
+        import datasets as hfds
+
+        patient_col = "p_num" if "p_num" in train_data.columns else "id"
+        bg_col = "bg_mM"
+        time_col = "datetime"
+
+        records = []
+        for pid, group in train_data.groupby(patient_col):
+            group = group.sort_values(time_col)
+            timestamps = pd.to_datetime(group[time_col]).tolist()
+            target = group[bg_col].values.astype(np.float32)
+
+            # Skip series that are too short
+            min_len = 3 * self._patch_size + self.config.forecast_length
+            if len(target) < min_len:
+                logger.warning(
+                    "Patient %s has only %d steps (need %d), skipping",
+                    pid, len(target), min_len,
+                )
+                continue
+
+            # Convert timestamps to strings for HF serialization
+            ts_strings = [t.isoformat() for t in timestamps]
+            # Include a dummy exogenous field (zeros) — required by
+            # transform_fev_dataset which always concatenates ev_fields.
+            records.append({
+                "timestamp": ts_strings,
+                "target": target.tolist(),
+                "feat_dynamic_real": np.zeros_like(target).tolist(),
+            })
+
+        if not records:
+            raise ValueError("No patient series long enough for fine-tuning")
+
+        info_print(f"Prepared {len(records)} patient series for fine-tuning")
+        return hfds.Dataset.from_list(records)
+
     def _prepare_training_data(
         self, train_data: Any
-    ) -> Tuple[DataLoader, Optional[DataLoader], Optional[DataLoader]]:
-        raise NotImplementedError("Toto training not yet implemented")
+    ) -> Tuple[Any, Optional[Any], Optional[Any]]:
+        """Prepare data for Toto fine-tuning.
 
-    def _save_checkpoint(self, output_dir: str) -> None:
-        pass
+        Converts the flat DataFrame to a HuggingFace Dataset, then wraps it
+        in a FinetuneDataModule. Returns (datamodule, None, None) — Lightning
+        handles train/val splitting internally.
+        """
+        from toto.data.datamodule.finetune_datamodule import FinetuneDataModule
 
-    def _load_checkpoint(self, model_dir: str) -> None:
-        pass
+        hf_dataset = self._dataframe_to_hf_dataset(train_data)
+
+        # Compute context length aligned to patch size
+        max_context_length = self.config.context_length
+        if max_context_length is None:
+            max_context_length = 8 * self._patch_size
+
+        dm = FinetuneDataModule(
+            dataset=hf_dataset,
+            max_context_length=max_context_length,
+            prediction_horizon=self.config.forecast_length,
+            patch_size=self._patch_size,
+            train_batch_size=self.config.train_batch_size,
+            val_batch_size=self.config.val_batch_size,
+            num_workers=0,
+            num_train_samples=1,
+            target_fields=["target"],
+            target_transform_fns=[lambda x: np.asarray(x, dtype=np.float32)],
+            ev_fields=["feat_dynamic_real"],
+            ev_transform_fns=[lambda x: np.asarray(x, dtype=np.float32)],
+        )
+
+        return (dm, None, None)
 
     def _train_model(
         self, train_data: Any, output_dir: str, **kwargs
     ) -> Dict[str, Any]:
-        raise NotImplementedError("Toto training not yet implemented")
+        """Fine-tune Toto using PyTorch Lightning.
+
+        The base class fit() passes raw train_data here for CUSTOM backends.
+        We call _prepare_training_data ourselves.
+        """
+        from lightning.pytorch import Trainer, seed_everything
+        from lightning.pytorch.callbacks import ModelCheckpoint, TQDMProgressBar
+        from lightning.pytorch.loggers import TensorBoardLogger
+        from toto.model.lightning_module import TotoForFinetuning
+
+        seed_everything(42, workers=True)
+
+        # Prepare data
+        dm, _, _ = self._prepare_training_data(train_data)
+
+        # Create Lightning module from current backbone
+        lightning_module = TotoForFinetuning(
+            pretrained_backbone=self.model,
+            val_prediction_len=self.config.val_prediction_len,
+            stable_steps=self.config.stable_steps,
+            decay_steps=self.config.decay_steps,
+            warmup_steps=self.config.warmup_steps,
+            lr=self.config.lr,
+            min_lr=self.config.min_lr,
+        )
+        lightning_module.to(self.device)
+
+        # Checkpointing
+        os.makedirs(output_dir, exist_ok=True)
+        ckpt_dir = os.path.join(output_dir, "checkpoints")
+
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=ckpt_dir,
+            filename="{epoch}-{step}-{val_loss:.4f}",
+            monitor="val_loss",
+            mode="min",
+            save_top_k=1,
+        )
+
+        tb_logger = TensorBoardLogger(
+            save_dir=output_dir,
+            name="toto_finetuning",
+        )
+
+        # Support both max_steps (Toto-native) and num_epochs (generic workflow).
+        # If num_epochs is set, use max_epochs; otherwise use max_steps.
+        trainer_kwargs = dict(
+            log_every_n_steps=1,
+            num_sanity_val_steps=0,
+            enable_progress_bar=True,
+            callbacks=[TQDMProgressBar(refresh_rate=10), checkpoint_callback],
+            logger=tb_logger,
+        )
+        if self.config.num_epochs is not None:
+            trainer_kwargs["max_epochs"] = self.config.num_epochs
+            info_print(f"Training for {self.config.num_epochs} epoch(s)")
+        else:
+            trainer_kwargs["max_steps"] = self.config.max_steps
+            info_print(f"Training for {self.config.max_steps} steps")
+
+        trainer = Trainer(**trainer_kwargs)
+
+        if self.config.num_epochs is not None:
+            info_print(f"Starting Toto fine-tuning for {self.config.num_epochs} epoch(s)...")
+        else:
+            info_print(f"Starting Toto fine-tuning for {self.config.max_steps} steps...")
+        trainer.fit(lightning_module, datamodule=dm)
+
+        best_ckpt = checkpoint_callback.best_model_path
+        best_score = (
+            float(checkpoint_callback.best_model_score)
+            if checkpoint_callback.best_model_score is not None
+            else None
+        )
+
+        # Load best checkpoint weights (not the final overfitted weights)
+        if best_ckpt and os.path.exists(best_ckpt):
+            info_print(f"Loading best checkpoint: {best_ckpt}")
+            best_lightning = TotoForFinetuning.load_from_checkpoint(
+                checkpoint_path=best_ckpt,
+                pretrained_backbone=lightning_module.model,
+                map_location=self.device,
+            )
+            self.model = best_lightning.model.to(self.device)
+        else:
+            info_print("No best checkpoint found, using final model weights")
+            self.model = lightning_module.model.to(self.device)
+
+        self.forecaster = _TotoForecaster(self.model)
+        self.is_fitted = True
+
+        info_print(f"Fine-tuning complete. Best checkpoint: {best_ckpt}")
+        if best_score is not None:
+            info_print(f"Best val_loss: {best_score:.4f}")
+
+        return {
+            "best_checkpoint": best_ckpt,
+            "best_val_loss": best_score,
+            "max_steps": self.config.max_steps,
+        }
+
+    @classmethod
+    def load(cls, model_path: str, config: Optional[TotoConfig] = None):
+        """Load a Toto model from a saved checkpoint.
+
+        Overrides the base class to use TotoConfig for deserialization.
+        """
+        if config is None:
+            config_path = os.path.join(model_path, "config.json")
+            if os.path.exists(config_path):
+                with open(config_path, "r") as f:
+                    config_dict = json.load(f)
+                config = TotoConfig(**config_dict)
+            else:
+                raise ValueError(f"No config found at {config_path}")
+
+        instance = cls(config)
+        instance._load_checkpoint(model_path)
+        return instance
+
+    def _save_checkpoint(self, output_dir: str) -> None:
+        """Save the fine-tuned model checkpoint.
+
+        Saves the backbone state dict and a reference JSON for loading.
+        """
+        if self.model is None:
+            return
+
+        os.makedirs(output_dir, exist_ok=True)
+        weights_path = os.path.join(output_dir, "toto_backbone.pt")
+        torch.save(self.model.state_dict(), weights_path)
+
+        ref_path = os.path.join(output_dir, "toto_checkpoint.json")
+        with open(ref_path, "w") as f:
+            json.dump({
+                "weights_file": "toto_backbone.pt",
+                "patch_size": self._patch_size,
+            }, f, indent=2)
+
+        logger.info("Toto checkpoint saved to %s", output_dir)
+
+    def _load_checkpoint(self, model_dir: str) -> None:
+        """Load a fine-tuned Toto checkpoint.
+
+        Loads the backbone state dict saved by _save_checkpoint.
+        """
+        ref_path = os.path.join(model_dir, "toto_checkpoint.json")
+        if os.path.exists(ref_path):
+            with open(ref_path) as f:
+                ref = json.load(f)
+            weights_path = os.path.join(model_dir, ref["weights_file"])
+        else:
+            # Fall back to looking for the weights file directly
+            weights_path = os.path.join(model_dir, "toto_backbone.pt")
+
+        if not os.path.exists(weights_path):
+            raise FileNotFoundError(
+                f"Toto checkpoint not found at {weights_path}"
+            )
+
+        state_dict = torch.load(weights_path, map_location=self.device)
+        self.model.load_state_dict(state_dict)
+        self.forecaster = _TotoForecaster(self.model)
+        self.is_fitted = True
+
+        logger.info("Toto checkpoint loaded from %s", weights_path)

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -99,7 +99,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         series = torch.stack(variates, dim=0).unsqueeze(0).to(self.device)
 
         ts_seconds_1d = torch.tensor(
-            [ts.timestamp() for ts in timestamps], dtype=torch.float32
+            timestamps.astype(np.int64) // 1_000_000_000, dtype=torch.float32
         )
         # Broadcast timestamps across all variates
         ts_seconds = (
@@ -162,7 +162,6 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         records = []
         for pid, group in train_data.groupby(patient_col):
             group = group.sort_values(time_col)
-            timestamps = pd.to_datetime(group[time_col]).tolist()
             target = group[bg_col].values.astype(np.float32)
 
             # Skip series that are too short
@@ -176,8 +175,11 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
                 )
                 continue
 
-            # Convert timestamps to strings for HF serialization
-            ts_strings = [t.isoformat() for t in timestamps]
+            ts_strings = (
+                pd.to_datetime(group[time_col])
+                .dt.strftime("%Y-%m-%dT%H:%M:%S")
+                .tolist()
+            )
             record = {
                 "timestamp": ts_strings,
                 "target": target.tolist(),

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -102,7 +102,12 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             [ts.timestamp() for ts in timestamps], dtype=torch.float32
         )
         # Broadcast timestamps across all variates
-        ts_seconds = ts_seconds_1d.unsqueeze(0).expand(series.shape[1], -1).unsqueeze(0).to(self.device)
+        ts_seconds = (
+            ts_seconds_1d.unsqueeze(0)
+            .expand(series.shape[1], -1)
+            .unsqueeze(0)
+            .to(self.device)
+        )
 
         # All variates share the same id_mask (same multivariate group)
         id_mask = torch.zeros_like(series)
@@ -165,7 +170,9 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             if len(target) < min_len:
                 logger.warning(
                     "Patient %s has only %d steps (need %d), skipping",
-                    pid, len(target), min_len,
+                    pid,
+                    len(target),
+                    min_len,
                 )
                 continue
 
@@ -218,7 +225,9 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         covariate_cols = self.config.covariate_cols or []
         if covariate_cols:
             ev_fields = list(covariate_cols)
-            ev_transform_fns = [lambda x: np.asarray(x, dtype=np.float32)] * len(covariate_cols)
+            ev_transform_fns = [lambda x: np.asarray(x, dtype=np.float32)] * len(
+                covariate_cols
+            )
             add_exogenous = True
         else:
             ev_fields = ["feat_dynamic_real"]
@@ -303,10 +312,14 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         )
         if self.config.num_epochs is not None:
             trainer_kwargs["max_epochs"] = self.config.num_epochs
-            info_print(f"Starting Toto fine-tuning for {self.config.num_epochs} epoch(s)...")
+            info_print(
+                f"Starting Toto fine-tuning for {self.config.num_epochs} epoch(s)..."
+            )
         else:
             trainer_kwargs["max_steps"] = self.config.max_steps
-            info_print(f"Starting Toto fine-tuning for {self.config.max_steps} steps...")
+            info_print(
+                f"Starting Toto fine-tuning for {self.config.max_steps} steps..."
+            )
 
         trainer = Trainer(**trainer_kwargs)
         trainer.fit(lightning_module, datamodule=dm)
@@ -376,9 +389,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             weights_path = os.path.join(model_dir, "toto_backbone.pt")
 
         if not os.path.exists(weights_path):
-            raise FileNotFoundError(
-                f"Toto checkpoint not found at {weights_path}"
-            )
+            raise FileNotFoundError(f"Toto checkpoint not found at {weights_path}")
 
         state_dict = torch.load(weights_path, map_location=self.device)
         # Enable variate labels if the checkpoint has them (covariate-trained model)

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import pandas as pd
 import torch
-from torch.utils.data import DataLoader
 
 from toto.model.toto import Toto
 from toto.data.util.dataset import MaskedTimeseries
@@ -18,7 +17,7 @@ from toto.inference.forecaster import TotoForecaster as _TotoForecaster
 
 from src.models.toto.config import TotoConfig
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
-from src.utils.logging_helper import info_print, error_print
+from src.utils.logging_helper import info_print
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +27,8 @@ INTERVAL_MINS = 5
 class TotoForecaster(BaseTimeSeriesFoundationModel):
     """Toto forecaster implementation."""
 
+    config_class = TotoConfig
     config: TotoConfig
-
-    def __init__(
-        self, config: TotoConfig, lora_config=None, distributed_config=None
-    ):
-        super().__init__(config, lora_config, distributed_config)
 
     def _initialize_model(self) -> None:
         """Load the Toto model from HuggingFace."""
@@ -75,9 +70,6 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         Returns:
             Forecast as 1D numpy array of shape (forecast_length,)
         """
-        if self.model is None:
-            raise ValueError("Model not initialized. Call _initialize_model first.")
-
         forecast_length = self.config.forecast_length
 
         bg_col = "bg_mM"
@@ -311,17 +303,12 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         )
         if self.config.num_epochs is not None:
             trainer_kwargs["max_epochs"] = self.config.num_epochs
-            info_print(f"Training for {self.config.num_epochs} epoch(s)")
-        else:
-            trainer_kwargs["max_steps"] = self.config.max_steps
-            info_print(f"Training for {self.config.max_steps} steps")
-
-        trainer = Trainer(**trainer_kwargs)
-
-        if self.config.num_epochs is not None:
             info_print(f"Starting Toto fine-tuning for {self.config.num_epochs} epoch(s)...")
         else:
+            trainer_kwargs["max_steps"] = self.config.max_steps
             info_print(f"Starting Toto fine-tuning for {self.config.max_steps} steps...")
+
+        trainer = Trainer(**trainer_kwargs)
         trainer.fit(lightning_module, datamodule=dm)
 
         best_ckpt = checkpoint_callback.best_model_path
@@ -345,7 +332,6 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             self.model = lightning_module.model.to(self.device)
 
         self.forecaster = _TotoForecaster(self.model)
-        self.is_fitted = True
 
         info_print(f"Fine-tuning complete. Best checkpoint: {best_ckpt}")
         if best_score is not None:
@@ -356,25 +342,6 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             "best_val_loss": best_score,
             "max_steps": self.config.max_steps,
         }
-
-    @classmethod
-    def load(cls, model_path: str, config: Optional[TotoConfig] = None):
-        """Load a Toto model from a saved checkpoint.
-
-        Overrides the base class to use TotoConfig for deserialization.
-        """
-        if config is None:
-            config_path = os.path.join(model_path, "config.json")
-            if os.path.exists(config_path):
-                with open(config_path, "r") as f:
-                    config_dict = json.load(f)
-                config = TotoConfig(**config_dict)
-            else:
-                raise ValueError(f"No config found at {config_path}")
-
-        instance = cls(config)
-        instance._load_checkpoint(model_path)
-        return instance
 
     def _save_checkpoint(self, output_dir: str) -> None:
         """Save the fine-tuned model checkpoint.
@@ -390,10 +357,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
 
         ref_path = os.path.join(output_dir, "toto_checkpoint.json")
         with open(ref_path, "w") as f:
-            json.dump({
-                "weights_file": "toto_backbone.pt",
-                "patch_size": self._patch_size,
-            }, f, indent=2)
+            json.dump({"weights_file": "toto_backbone.pt"}, f, indent=2)
 
         logger.info("Toto checkpoint saved to %s", output_dir)
 

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -1,0 +1,134 @@
+"""
+Toto model implementation using the base TSFM framework.
+"""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from toto.model.toto import Toto
+from toto.data.util.dataset import MaskedTimeseries
+from toto.inference.forecaster import TotoForecaster as _TotoForecaster
+
+from src.models.toto.config import TotoConfig
+from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.utils.logging_helper import info_print, error_print
+
+logger = logging.getLogger(__name__)
+
+INTERVAL_MINS = 5
+
+
+class TotoForecaster(BaseTimeSeriesFoundationModel):
+    """Toto forecaster implementation."""
+
+    config: TotoConfig
+
+    def __init__(
+        self, config: TotoConfig, lora_config=None, distributed_config=None
+    ):
+        super().__init__(config, lora_config, distributed_config)
+
+    def _initialize_model(self) -> None:
+        """Load the Toto model from HuggingFace."""
+        info_print("Initializing Toto model from Datadog/Toto-Open-Base-1.0...")
+
+        toto = Toto.from_pretrained("Datadog/Toto-Open-Base-1.0")
+
+        use_cuda = torch.cuda.is_available() and not getattr(
+            self.config, "use_cpu", False
+        )
+        self.device = "cuda" if use_cuda else "cpu"
+        toto.to(self.device)
+
+        self.model = toto.model
+        self.forecaster = _TotoForecaster(self.model)
+
+        info_print(f"Toto model initialized on {self.device}")
+
+    @property
+    def training_backend(self) -> TrainingBackend:
+        return TrainingBackend.CUSTOM
+
+    @property
+    def supports_lora(self) -> bool:
+        return False
+
+    @property
+    def supports_zero_shot(self) -> bool:
+        return True
+
+    def predict(self, data: pd.DataFrame, **kwargs) -> np.ndarray:
+        """Make predictions given context data.
+
+        Args:
+            data: DataFrame with 'bg_mM' column and a DatetimeIndex
+            **kwargs: Additional options (unused for zero-shot)
+
+        Returns:
+            Forecast as 1D numpy array of shape (forecast_length,)
+        """
+        if self.model is None:
+            raise ValueError("Model not initialized. Call _initialize_model first.")
+
+        forecast_length = self.config.forecast_length
+
+        bg_col = "bg_mM"
+        if bg_col not in data.columns:
+            raise ValueError(f"DataFrame must contain '{bg_col}' column")
+
+        context = data[bg_col].values
+        timestamps = data.index
+
+        # Build MaskedTimeseries input
+        series = (
+            torch.tensor(context, dtype=torch.float32).unsqueeze(0).to(self.device)
+        )
+        ts_seconds = (
+            torch.tensor(
+                [ts.timestamp() for ts in timestamps], dtype=torch.float32
+            )
+            .unsqueeze(0)
+            .to(self.device)
+        )
+
+        inputs = MaskedTimeseries(
+            series=series,
+            padding_mask=torch.ones_like(series, dtype=torch.bool),
+            id_mask=torch.zeros_like(series),
+            timestamp_seconds=ts_seconds,
+            time_interval_seconds=torch.tensor(
+                [INTERVAL_MINS * 60], dtype=torch.float32
+            ).to(self.device),
+        )
+
+        with torch.no_grad():
+            forecast = self.forecaster.forecast(
+                inputs,
+                prediction_length=forecast_length,
+                num_samples=self.config.num_samples,
+                samples_per_batch=self.config.samples_per_batch,
+            )
+
+        return forecast.median.cpu().numpy()[0]
+
+    # Stub implementations for abstract methods (zero-shot only for now)
+    def _prepare_training_data(
+        self, train_data: Any
+    ) -> Tuple[DataLoader, Optional[DataLoader], Optional[DataLoader]]:
+        raise NotImplementedError("Toto training not yet implemented")
+
+    def _save_checkpoint(self, output_dir: str) -> None:
+        pass
+
+    def _load_checkpoint(self, model_dir: str) -> None:
+        pass
+
+    def _train_model(
+        self, train_data: Any, output_dir: str, **kwargs
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Toto training not yet implemented")

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -85,28 +85,46 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             raise ValueError(f"DataFrame must contain '{bg_col}' column")
 
         context = data[bg_col].values
-        timestamps = data.index
+        # Timestamps may be in the index (DatetimeIndex) or a 'datetime' column
+        if isinstance(data.index, pd.DatetimeIndex):
+            timestamps = data.index
+        elif "datetime" in data.columns:
+            timestamps = pd.to_datetime(data["datetime"])
+        else:
+            raise ValueError("Data must have a DatetimeIndex or 'datetime' column")
 
-        # Build MaskedTimeseries input
-        series = (
-            torch.tensor(context, dtype=torch.float32).unsqueeze(0).to(self.device)
+        # Build variate list: target (BG) first, then covariates at the end
+        variates = [torch.tensor(context, dtype=torch.float32)]
+        covariate_cols = self.config.covariate_cols or []
+        for col in covariate_cols:
+            if col not in data.columns:
+                raise ValueError(f"Covariate column '{col}' not found in data")
+            variates.append(torch.tensor(data[col].values, dtype=torch.float32))
+
+        num_exogenous = len(covariate_cols)
+
+        # Stack variates: shape (1, num_variates, series_len)
+        series = torch.stack(variates, dim=0).unsqueeze(0).to(self.device)
+
+        ts_seconds_1d = torch.tensor(
+            [ts.timestamp() for ts in timestamps], dtype=torch.float32
         )
-        ts_seconds = (
-            torch.tensor(
-                [ts.timestamp() for ts in timestamps], dtype=torch.float32
-            )
-            .unsqueeze(0)
-            .to(self.device)
-        )
+        # Broadcast timestamps across all variates
+        ts_seconds = ts_seconds_1d.unsqueeze(0).expand(series.shape[1], -1).unsqueeze(0).to(self.device)
+
+        # All variates share the same id_mask (same multivariate group)
+        id_mask = torch.zeros_like(series)
+        interval = torch.tensor(
+            [INTERVAL_MINS * 60] * series.shape[1], dtype=torch.float32
+        ).to(self.device)
 
         inputs = MaskedTimeseries(
             series=series,
             padding_mask=torch.ones_like(series, dtype=torch.bool),
-            id_mask=torch.zeros_like(series),
+            id_mask=id_mask,
             timestamp_seconds=ts_seconds,
-            time_interval_seconds=torch.tensor(
-                [INTERVAL_MINS * 60], dtype=torch.float32
-            ).to(self.device),
+            time_interval_seconds=interval,
+            num_exogenous_variables=num_exogenous,
         )
 
         with torch.no_grad():
@@ -117,19 +135,19 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
                 samples_per_batch=self.config.samples_per_batch,
             )
 
-        # When num_samples is None, forecast has .mean only (single forward pass).
-        # When num_samples is set, use .median across sampled trajectories.
+        # forecast shape: (batch, variates, future_time_steps)
+        # Extract only the first variate (target BG), ignore exogenous forecasts
         if self.config.num_samples is None:
-            result = forecast.mean.cpu().numpy()
+            result = forecast.mean[:, 0, :].cpu().numpy()
         else:
-            result = forecast.median.cpu().numpy()
+            result = forecast.median[:, 0, :].cpu().numpy()
         return result.flatten()
 
     def _dataframe_to_hf_dataset(self, train_data: pd.DataFrame):
         """Convert a flat DataFrame to HuggingFace Dataset format for Toto.
 
         Each patient's contiguous BG series becomes one row in the HF dataset
-        with 'timestamp' and 'target' fields.
+        with 'timestamp', 'target', and optional covariate fields.
 
         Args:
             train_data: DataFrame with 'bg_mM', 'datetime', and 'p_num' columns.
@@ -142,6 +160,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         patient_col = "p_num" if "p_num" in train_data.columns else "id"
         bg_col = "bg_mM"
         time_col = "datetime"
+        covariate_cols = self.config.covariate_cols or []
 
         records = []
         for pid, group in train_data.groupby(patient_col):
@@ -160,18 +179,30 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
 
             # Convert timestamps to strings for HF serialization
             ts_strings = [t.isoformat() for t in timestamps]
-            # Include a dummy exogenous field (zeros) — required by
-            # transform_fev_dataset which always concatenates ev_fields.
-            records.append({
+            record = {
                 "timestamp": ts_strings,
                 "target": target.tolist(),
-                "feat_dynamic_real": np.zeros_like(target).tolist(),
-            })
+            }
+
+            # Add covariates as separate fields (each becomes an ev_field)
+            if covariate_cols:
+                for col in covariate_cols:
+                    values = group[col].values.astype(np.float32)
+                    # Fill NaNs with 0 for covariates
+                    values = np.nan_to_num(values, nan=0.0)
+                    record[col] = values.tolist()
+            else:
+                # Dummy exogenous field required by transform_fev_dataset
+                record["feat_dynamic_real"] = np.zeros_like(target).tolist()
+
+            records.append(record)
 
         if not records:
             raise ValueError("No patient series long enough for fine-tuning")
 
         info_print(f"Prepared {len(records)} patient series for fine-tuning")
+        if covariate_cols:
+            info_print(f"  Covariates: {covariate_cols}")
         return hfds.Dataset.from_list(records)
 
     def _prepare_training_data(
@@ -192,6 +223,16 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         if max_context_length is None:
             max_context_length = 8 * self._patch_size
 
+        covariate_cols = self.config.covariate_cols or []
+        if covariate_cols:
+            ev_fields = list(covariate_cols)
+            ev_transform_fns = [lambda x: np.asarray(x, dtype=np.float32)] * len(covariate_cols)
+            add_exogenous = True
+        else:
+            ev_fields = ["feat_dynamic_real"]
+            ev_transform_fns = [lambda x: np.asarray(x, dtype=np.float32)]
+            add_exogenous = False
+
         dm = FinetuneDataModule(
             dataset=hf_dataset,
             max_context_length=max_context_length,
@@ -201,10 +242,11 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             val_batch_size=self.config.val_batch_size,
             num_workers=0,
             num_train_samples=1,
+            add_exogenous_features=add_exogenous,
             target_fields=["target"],
             target_transform_fns=[lambda x: np.asarray(x, dtype=np.float32)],
-            ev_fields=["feat_dynamic_real"],
-            ev_transform_fns=[lambda x: np.asarray(x, dtype=np.float32)],
+            ev_fields=ev_fields,
+            ev_transform_fns=ev_transform_fns,
         )
 
         return (dm, None, None)
@@ -228,6 +270,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         dm, _, _ = self._prepare_training_data(train_data)
 
         # Create Lightning module from current backbone
+        has_covariates = bool(self.config.covariate_cols)
         lightning_module = TotoForFinetuning(
             pretrained_backbone=self.model,
             val_prediction_len=self.config.val_prediction_len,
@@ -236,6 +279,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             warmup_steps=self.config.warmup_steps,
             lr=self.config.lr,
             min_lr=self.config.min_lr,
+            add_exogenous_features=has_covariates,
         )
         lightning_module.to(self.device)
 
@@ -373,6 +417,9 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             )
 
         state_dict = torch.load(weights_path, map_location=self.device)
+        # Enable variate labels if the checkpoint has them (covariate-trained model)
+        if "target_variate_label" in state_dict:
+            self.model.enable_variate_labels()
         self.model.load_state_dict(state_dict)
         self.forecaster = _TotoForecaster(self.model)
         self.is_fitted = True

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -18,12 +18,14 @@ from toto.inference.forecaster import TotoForecaster as _TotoForecaster
 from src.models.toto.config import TotoConfig
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
 from src.utils.logging_helper import info_print
+from utils.model_registry import ModelRegistry
 
 logger = logging.getLogger(__name__)
 
 INTERVAL_MINS = 5
 
 
+@ModelRegistry.register("toto")
 class TotoForecaster(BaseTimeSeriesFoundationModel):
     """Toto forecaster implementation."""
 

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -157,6 +157,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         self,
         data: pd.DataFrame,
         episode_col: str,
+        quantile_levels: Optional[List[float]] = None,
     ) -> Dict[str, np.ndarray]:
         """Batched prediction: stack episodes into one forward pass.
 
@@ -262,6 +263,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             record = {
                 "timestamp": ts_strings,
                 "target": target.tolist(),
+                "freq": f"{INTERVAL_MINS}min",
             }
 
             # Add covariates as separate fields (each becomes an ev_field)

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -5,7 +5,7 @@ Toto model implementation using the base TSFM framework.
 import json
 import logging
 import os
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -60,85 +60,164 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
     def supports_zero_shot(self) -> bool:
         return True
 
-    def _predict(self, data: pd.DataFrame, **kwargs) -> np.ndarray:
-        """Make predictions given context data.
+    # ------------------------------------------------------------------
+    # Shared inference helpers
+    # ------------------------------------------------------------------
 
-        Args:
-            data: DataFrame with 'bg_mM' column and a DatetimeIndex
-            **kwargs: Additional options (unused for zero-shot)
+    @staticmethod
+    def _extract_timestamps(data: pd.DataFrame) -> pd.DatetimeIndex:
+        """Get timestamps from DatetimeIndex or 'datetime' column."""
+        if isinstance(data.index, pd.DatetimeIndex):
+            return data.index
+        if "datetime" in data.columns:
+            return pd.DatetimeIndex(pd.to_datetime(data["datetime"]))
+        raise ValueError("Data must have a DatetimeIndex or 'datetime' column")
 
-        Returns:
-            Forecast as 1D numpy array of shape (forecast_length,)
-        """
-        forecast_length = self.config.forecast_length
+    @staticmethod
+    def _timestamps_to_seconds(timestamps: pd.DatetimeIndex) -> torch.Tensor:
+        """Convert pandas timestamps to seconds-since-epoch float tensor."""
+        return torch.tensor(
+            np.asarray(timestamps.astype(np.int64)) // 1_000_000_000,
+            dtype=torch.float32,
+        )
 
+    def _build_variates(self, data: pd.DataFrame) -> List[torch.Tensor]:
+        """Extract BG target + covariate tensors from a single episode."""
         bg_col = "bg_mM"
         if bg_col not in data.columns:
             raise ValueError(f"DataFrame must contain '{bg_col}' column")
-
-        context = data[bg_col].values
-        # Timestamps may be in the index (DatetimeIndex) or a 'datetime' column
-        if isinstance(data.index, pd.DatetimeIndex):
-            timestamps = data.index
-        elif "datetime" in data.columns:
-            timestamps = pd.to_datetime(data["datetime"])
-        else:
-            raise ValueError("Data must have a DatetimeIndex or 'datetime' column")
-
-        # Build variate list: target (BG) first, then covariates at the end
-        variates = [torch.tensor(context, dtype=torch.float32)]
-        covariate_cols = self.config.covariate_cols or []
-        for col in covariate_cols:
+        variates = [torch.tensor(data[bg_col].values, dtype=torch.float32)]
+        for col in self.config.covariate_cols or []:
             if col not in data.columns:
                 raise ValueError(f"Covariate column '{col}' not found in data")
             variates.append(torch.tensor(data[col].values, dtype=torch.float32))
+        return variates
 
-        num_exogenous = len(covariate_cols)
+    def _extract_bg_forecast(self, forecast) -> np.ndarray:
+        """Extract BG (variate 0) from a Toto Forecast object.
 
-        # Stack variates: shape (1, num_variates, series_len)
+        Returns shape (batch, forecast_length). Uses median when sampling,
+        mean otherwise.
+        """
+        if self.config.num_samples is None:
+            return forecast.mean[:, 0, :].cpu().numpy()
+        return forecast.median[:, 0, :].cpu().numpy()
+
+    def _run_forecast(self, inputs: MaskedTimeseries) -> np.ndarray:
+        """Run forecaster and return BG predictions as numpy array."""
+        with torch.no_grad():
+            forecast = self.forecaster.forecast(
+                inputs,
+                prediction_length=self.config.forecast_length,
+                num_samples=self.config.num_samples,
+                samples_per_batch=self.config.samples_per_batch,
+            )
+        return self._extract_bg_forecast(forecast)
+
+    # ------------------------------------------------------------------
+    # Prediction
+    # ------------------------------------------------------------------
+
+    def _predict(self, data: pd.DataFrame, **kwargs) -> np.ndarray:
+        """Predict a single episode. Returns 1D array of shape (forecast_length,)."""
+        timestamps = self._extract_timestamps(data)
+        variates = self._build_variates(data)
+        num_covariates = len(self.config.covariate_cols or [])
+
+        # (1, num_variates, series_len)
         series = torch.stack(variates, dim=0).unsqueeze(0).to(self.device)
+        num_variates = series.shape[1]
 
-        ts_seconds_1d = torch.tensor(
-            timestamps.astype(np.int64) // 1_000_000_000, dtype=torch.float32
-        )
-        # Broadcast timestamps across all variates
+        # Broadcast timestamps to (1, num_variates, series_len)
         ts_seconds = (
-            ts_seconds_1d.unsqueeze(0)
-            .expand(series.shape[1], -1)
+            self._timestamps_to_seconds(timestamps)
+            .unsqueeze(0)
+            .expand(num_variates, -1)
             .unsqueeze(0)
             .to(self.device)
         )
 
-        # All variates share the same id_mask (same multivariate group)
-        id_mask = torch.zeros_like(series)
-        interval = torch.tensor(
-            [INTERVAL_MINS * 60] * series.shape[1], dtype=torch.float32
-        ).to(self.device)
-
         inputs = MaskedTimeseries(
             series=series,
             padding_mask=torch.ones_like(series, dtype=torch.bool),
-            id_mask=id_mask,
+            id_mask=torch.zeros_like(series),
             timestamp_seconds=ts_seconds,
-            time_interval_seconds=interval,
-            num_exogenous_variables=num_exogenous,
+            time_interval_seconds=torch.full(
+                (num_variates,),
+                INTERVAL_MINS * 60,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            num_exogenous_variables=num_covariates,
         )
 
-        with torch.no_grad():
-            forecast = self.forecaster.forecast(
-                inputs,
-                prediction_length=forecast_length,
-                num_samples=self.config.num_samples,
-                samples_per_batch=self.config.samples_per_batch,
-            )
+        return self._run_forecast(inputs).flatten()
 
-        # forecast shape: (batch, variates, future_time_steps)
-        # Extract only the first variate (target BG), ignore exogenous forecasts
-        if self.config.num_samples is None:
-            result = forecast.mean[:, 0, :].cpu().numpy()
-        else:
-            result = forecast.median[:, 0, :].cpu().numpy()
-        return result.flatten()
+    def _predict_batch(
+        self,
+        data: pd.DataFrame,
+        episode_col: str,
+    ) -> Dict[str, np.ndarray]:
+        """Batched prediction: stack episodes into one forward pass.
+
+        Episodes are left-padded to the longest context length so the most
+        recent timesteps are right-aligned. The padding_mask tells the model
+        which timesteps are real data.
+        """
+        covariate_cols = self.config.covariate_cols or []
+        num_covariates = len(covariate_cols)
+        num_variates = 1 + num_covariates
+
+        # Group episodes and build per-episode tensors
+        episode_ids: List[str] = []
+        all_series: List[torch.Tensor] = []  # each (num_variates, T)
+        all_ts: List[torch.Tensor] = []  # each (T,)
+
+        for ep_id, ep_data in data.groupby(episode_col):
+            episode_ids.append(str(ep_id))
+            all_ts.append(
+                self._timestamps_to_seconds(self._extract_timestamps(ep_data))
+            )
+            all_series.append(torch.stack(self._build_variates(ep_data), dim=0))
+
+        if not episode_ids:
+            return {}
+
+        # Left-pad to max length so recent context is right-aligned
+        max_len = max(s.shape[1] for s in all_series)
+        batch_size = len(all_series)
+
+        series = torch.zeros(batch_size, num_variates, max_len)
+        padding_mask = torch.zeros(batch_size, num_variates, max_len, dtype=torch.bool)
+        ts_batch = torch.zeros(batch_size, num_variates, max_len)
+
+        for i, (s, ts) in enumerate(zip(all_series, all_ts)):
+            series_len = s.shape[1]
+            pad_start = max_len - series_len
+            series[i, :, pad_start:] = s
+            padding_mask[i, :, pad_start:] = True
+            ts_batch[i, :, pad_start:] = ts.unsqueeze(0).expand(num_variates, -1)
+
+        series = series.to(self.device)
+        padding_mask = padding_mask.to(self.device)
+        ts_batch = ts_batch.to(self.device)
+
+        inputs = MaskedTimeseries(
+            series=series,
+            padding_mask=padding_mask,
+            id_mask=torch.zeros_like(series),
+            timestamp_seconds=ts_batch,
+            time_interval_seconds=torch.full(
+                (batch_size, num_variates),
+                INTERVAL_MINS * 60,
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            num_exogenous_variables=num_covariates,
+        )
+
+        preds = self._run_forecast(inputs)
+        return {eid: preds[i] for i, eid in enumerate(episode_ids)}
 
     def _dataframe_to_hf_dataset(self, train_data: pd.DataFrame):
         """Convert a flat DataFrame to HuggingFace Dataset format for Toto.


### PR DESCRIPTION
### Summary

- **Add Toto forecaster**: Full implementation of `TotoForecaster` for `Datadog/Toto-Open-Base-1.0`, supporting zero-shot inference, LoRA-free fine-tuning via PyTorch Lightning, checkpoint save/load, and resumed training. Supports BG-only and covariate configs.
- **Fix base class config deserialization** (`base_model.py`): `BaseTimeSeriesFoundationModel.load()` previously hardcoded `ModelConfig.from_dict()`, which crashed when loading any subclass model whose `config.json` contained subclass-specific fields (e.g. `covariate_cols`, `fine_tune_steps`). Fixed by:
  1. Adding a `config_class` class variable to the base (defaults to `ModelConfig`) that subclasses override to point at their own config dataclass.
  2. Updating `from_dict()` to auto-coerce serialized `TrainingBackend` strings back to the enum, so subclasses don't each have to handle this themselves. This let us **delete the duplicated `load()` overrides** in `Chronos2Forecaster` and `TiDEForecaster` (~60 lines removed).

Closes #316.

### Testing
- `example_holdout_generic_workflow.py --model-type toto` passes all 7 steps (zero-shot → train → save → load → resume → eval)
- Same for `chronos2` and `tide` (load() regression: verifies the base class fix doesn't break existing models)
