### PR TITLE
refactor: add ModelRegistry for class-based model resolution

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,22 +2,4 @@
 
 from src.models.factory import create_model_and_config
 
-# Trigger @ModelRegistry.register() for all model classes.
-# Missing optional deps (autogluon, tsfm_public, etc.) are silently skipped.
-for _mod in [
-    "src.models.ttm",
-    "src.models.chronos2",
-    "src.models.tide",
-    "src.models.sundial",
-    "src.models.tsmixer",
-    "src.models.timesfm",
-    "src.models.timegrad",
-    "src.models.moirai",
-    "src.models.moment",
-]:
-    try:
-        __import__(_mod)
-    except ModuleNotFoundError:
-        pass
-
 __all__ = ["create_model_and_config"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,78 +1,23 @@
 """Model module exports."""
 
-import logging as _logging
-
 from src.models.factory import create_model_and_config
 
-# Trigger @ModelRegistry.register() side-effects for all model classes.
-# Each import below ensures the decorator has run and the class is present
-# in ModelRegistry._registry.  Imports are wrapped in try/except because
-# many models depend on optional heavy packages (tsfm_public, autogluon,
-# gluonts/pts, moirai, momentfm) that may not be installed.
-
-_logger = _logging.getLogger(__name__)
-
-try:
-    from src.models.ttm import TTMForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import TTMForecaster for registry", exc_info=True)
-
-try:
-    from src.models.chronos2 import Chronos2Forecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import Chronos2Forecaster for registry", exc_info=True)
-
-try:
-    from src.models.tide import TiDEForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import TiDEForecaster for registry", exc_info=True)
-
-try:
-    from src.models.sundial import SundialForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import SundialForecaster for registry", exc_info=True)
-
-try:
-    from src.models.tsmixer import TSMixerForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import TSMixerForecaster for registry", exc_info=True)
-
-try:
-    from src.models.timesfm import TimesFMForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import TimesFMForecaster for registry", exc_info=True)
-
-try:
-    from src.models.timegrad import TimeGradForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import TimeGradForecaster for registry", exc_info=True)
-
-try:
-    from src.models.moirai import MoiraiForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import MoiraiForecaster for registry", exc_info=True)
-
-try:
-    from src.models.moment import MomentForecaster  # noqa: F401
-except ImportError:
-    pass
-except Exception:
-    _logger.debug("Failed to import MomentForecaster for registry", exc_info=True)
+# Trigger @ModelRegistry.register() for all model classes.
+# Missing optional deps (autogluon, tsfm_public, etc.) are silently skipped.
+for _mod in [
+    "src.models.ttm",
+    "src.models.chronos2",
+    "src.models.tide",
+    "src.models.sundial",
+    "src.models.tsmixer",
+    "src.models.timesfm",
+    "src.models.timegrad",
+    "src.models.moirai",
+    "src.models.moment",
+]:
+    try:
+        __import__(_mod)
+    except ImportError:
+        pass
 
 __all__ = ["create_model_and_config"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -17,7 +17,7 @@ for _mod in [
 ]:
     try:
         __import__(_mod)
-    except ImportError:
+    except ModuleNotFoundError:
         pass
 
 __all__ = ["create_model_and_config"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,78 @@
 """Model module exports."""
 
+import logging as _logging
+
 from src.models.factory import create_model_and_config
+
+# Trigger @ModelRegistry.register() side-effects for all model classes.
+# Each import below ensures the decorator has run and the class is present
+# in ModelRegistry._registry.  Imports are wrapped in try/except because
+# many models depend on optional heavy packages (tsfm_public, autogluon,
+# gluonts/pts, moirai, momentfm) that may not be installed.
+
+_logger = _logging.getLogger(__name__)
+
+try:
+    from src.models.ttm import TTMForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import TTMForecaster for registry", exc_info=True)
+
+try:
+    from src.models.chronos2 import Chronos2Forecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import Chronos2Forecaster for registry", exc_info=True)
+
+try:
+    from src.models.tide import TiDEForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import TiDEForecaster for registry", exc_info=True)
+
+try:
+    from src.models.sundial import SundialForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import SundialForecaster for registry", exc_info=True)
+
+try:
+    from src.models.tsmixer import TSMixerForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import TSMixerForecaster for registry", exc_info=True)
+
+try:
+    from src.models.timesfm import TimesFMForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import TimesFMForecaster for registry", exc_info=True)
+
+try:
+    from src.models.timegrad import TimeGradForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import TimeGradForecaster for registry", exc_info=True)
+
+try:
+    from src.models.moirai import MoiraiForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import MoiraiForecaster for registry", exc_info=True)
+
+try:
+    from src.models.moment import MomentForecaster  # noqa: F401
+except ImportError:
+    pass
+except Exception:
+    _logger.debug("Failed to import MomentForecaster for registry", exc_info=True)
 
 __all__ = ["create_model_and_config"]

--- a/src/models/base/__init__.py
+++ b/src/models/base/__init__.py
@@ -14,6 +14,8 @@ from .base_model import (
     create_model_from_config,
 )
 
+from .registry import ModelRegistry
+
 from .distributed import (
     DistributedManager,
     setup_deepspeed_config,
@@ -45,6 +47,8 @@ __all__ = [
     "TrainingBackend",
     # Factory functions
     "create_model_from_config",
+    # Registry
+    "ModelRegistry",
     # Distributed training
     "DistributedManager",
     "setup_deepspeed_config",

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -1,12 +1,7 @@
 """ModelRegistry: maps short names to model classes via decorator."""
 
-from __future__ import annotations
-
 import importlib
-from typing import TYPE_CHECKING, Dict, List, Type
-
-if TYPE_CHECKING:
-    from src.models.base.base_model import BaseTimeSeriesFoundationModel
+from typing import Dict, List, Type
 
 # Module paths for lazy import — only loaded when get() is called.
 _MODEL_MODULES: Dict[str, str] = {
@@ -25,7 +20,7 @@ _MODEL_MODULES: Dict[str, str] = {
 class ModelRegistry:
     """Maps short names (e.g. "ttm", "chronos2") to model classes."""
 
-    _registry: Dict[str, Type["BaseTimeSeriesFoundationModel"]] = {}
+    _registry: Dict[str, Type] = {}
 
     @classmethod
     def register(cls, name: str):
@@ -43,7 +38,7 @@ class ModelRegistry:
         return decorator
 
     @classmethod
-    def get(cls, name: str) -> Type["BaseTimeSeriesFoundationModel"]:
+    def get(cls, name: str) -> Type:
         # Lazy import: if not yet registered, try importing the module.
         if name not in cls._registry:
             mod_path = _MODEL_MODULES.get(name)

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -51,8 +51,7 @@ class ModelRegistry:
                 importlib.import_module(mod_path)
         if name not in cls._registry:
             raise KeyError(
-                f"Model '{name}' not registered. "
-                f"Available: {sorted(cls._registry.keys())}"
+                f"Model '{name}' not registered. " f"Known: {cls.list_models()}"
             )
         return cls._registry[name]
 

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Type
+import importlib
+from typing import TYPE_CHECKING, Dict, List, Type
 
 if TYPE_CHECKING:
     from src.models.base.base_model import BaseTimeSeriesFoundationModel
+
+# Module paths for lazy import — only loaded when get() is called.
+_MODEL_MODULES: Dict[str, str] = {
+    "ttm": "src.models.ttm",
+    "chronos2": "src.models.chronos2",
+    "tide": "src.models.tide",
+    "sundial": "src.models.sundial",
+    "tsmixer": "src.models.tsmixer",
+    "timesfm": "src.models.timesfm",
+    "timegrad": "src.models.timegrad",
+    "moirai": "src.models.moirai",
+    "moment": "src.models.moment",
+}
 
 
 class ModelRegistry:
@@ -30,6 +44,11 @@ class ModelRegistry:
 
     @classmethod
     def get(cls, name: str) -> Type["BaseTimeSeriesFoundationModel"]:
+        # Lazy import: if not yet registered, try importing the module.
+        if name not in cls._registry:
+            mod_path = _MODEL_MODULES.get(name)
+            if mod_path is not None:
+                importlib.import_module(mod_path)
         if name not in cls._registry:
             raise KeyError(
                 f"Model '{name}' not registered. "
@@ -38,5 +57,21 @@ class ModelRegistry:
         return cls._registry[name]
 
     @classmethod
-    def list_models(cls) -> list[str]:
-        return sorted(cls._registry.keys())
+    def list_models(cls) -> List[str]:
+        return sorted(_MODEL_MODULES.keys())
+
+    @classmethod
+    def available_models(cls) -> List[str]:
+        """Models whose dependencies are actually installed."""
+        result: List[str] = []
+        for name, mod_path in _MODEL_MODULES.items():
+            if name in cls._registry:
+                result.append(name)
+                continue
+            try:
+                importlib.import_module(mod_path)
+                if name in cls._registry:
+                    result.append(name)
+            except ModuleNotFoundError:
+                pass
+        return sorted(result)

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -43,7 +43,13 @@ class ModelRegistry:
         if name not in cls._registry:
             mod_path = _MODEL_MODULES.get(name)
             if mod_path is not None:
-                importlib.import_module(mod_path)
+                try:
+                    importlib.import_module(mod_path)
+                except (ModuleNotFoundError, ImportError) as exc:
+                    raise KeyError(
+                        f"Model '{name}' found in registry but failed to import "
+                        f"({mod_path}): {exc}"
+                    ) from exc
         if name not in cls._registry:
             raise KeyError(
                 f"Model '{name}' not registered. " f"Known: {cls.list_models()}"

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""
+ModelRegistry: class-based registry for time series foundation models.
+
+Models self-register via the ``@ModelRegistry.register("name")`` decorator.
+The registry allows workflows to resolve a model class by a short name
+(e.g. "ttm", "chronos2") without hardcoding if/elif dispatch chains.
+
+Design notes
+------------
+- Registration is a pure class-level side-effect: no singleton objects,
+  no global state beyond the _registry dict.
+- The registry does NOT create model instances — callers still construct
+  the model-specific config and pass it to the class.  This is intentional:
+  every model has a different config type (TTMConfig, Chronos2Config, …),
+  and the registry should not paper over those differences.
+- ``load_from_checkpoint()`` reads the ``model_type`` field written by
+  ``BaseTimeSeriesFoundationModel.save()`` into ``metadata.json`` and
+  resolves the class, then delegates to ``cls.load()``.  The ``model_type``
+  stored there is the *registry key* (e.g. "ttm"), not the class name.
+  For checkpoints saved before the registry existed the lookup falls back
+  to a class-name-to-key mapping.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Type
+
+if TYPE_CHECKING:  # pragma: no cover
+    from src.models.base.base_model import BaseTimeSeriesFoundationModel
+
+
+# Fallback: map class names (as stored in old metadata.json) to registry keys.
+# Only needed for checkpoints saved before @ModelRegistry.register was added.
+_CLASS_NAME_TO_KEY: Dict[str, str] = {
+    "TTMForecaster": "ttm",
+    "Chronos2Forecaster": "chronos2",
+    "TiDEForecaster": "tide",
+    "TimesFMForecaster": "timesfm",
+    "TimeGradForecaster": "timegrad",
+    "TSMixerForecaster": "tsmixer",
+    "SundialForecaster": "sundial",
+    "MoiraiForecaster": "moirai",
+    "MomentForecaster": "moment",
+}
+
+
+class ModelRegistry:
+    """Class-based registry mapping short names to model classes.
+
+    Usage
+    -----
+    Register a model (done once, at import time)::
+
+        @ModelRegistry.register("ttm")
+        class TTMForecaster(BaseTimeSeriesFoundationModel):
+            ...
+
+    Look up the class in a workflow::
+
+        cls = ModelRegistry.get("ttm")
+        config = TTMConfig(...)
+        model = cls(config)
+
+    Load from a checkpoint (class resolved from metadata.json)::
+
+        model = ModelRegistry.load_from_checkpoint("/path/to/checkpoint")
+    """
+
+    _registry: Dict[str, Type["BaseTimeSeriesFoundationModel"]] = {}
+
+    @classmethod
+    def register(cls, name: str):
+        """Decorator that registers a model class under ``name``.
+
+        Args:
+            name: Short identifier for the model (e.g. "ttm", "chronos2").
+                  Must be unique within the registry.
+
+        Returns:
+            The original class, unmodified (decorator is non-wrapping).
+
+        Raises:
+            ValueError: If ``name`` is already registered to a *different* class.
+                        Re-registering the same class under the same name is a
+                        no-op (safe for reload scenarios in interactive sessions).
+        """
+
+        def decorator(model_cls: Type) -> Type:
+            existing = cls._registry.get(name)
+            if existing is not None and existing is not model_cls:
+                raise ValueError(
+                    f"Cannot register '{model_cls.__name__}' as '{name}': "
+                    f"already registered to '{existing.__name__}'. "
+                    f"Use a unique name or unregister the existing entry first."
+                )
+            cls._registry[name] = model_cls
+            return model_cls
+
+        return decorator
+
+    @classmethod
+    def get(cls, name: str) -> Type["BaseTimeSeriesFoundationModel"]:
+        """Return the model class registered under ``name``.
+
+        Args:
+            name: Registry key (e.g. "ttm", "chronos2").
+
+        Returns:
+            The model class (not an instance).
+
+        Raises:
+            KeyError: If ``name`` is not in the registry.  The error message
+                      lists all currently registered names to aid debugging.
+        """
+        if name not in cls._registry:
+            raise KeyError(
+                f"Model '{name}' is not registered. "
+                f"Available models: {sorted(cls._registry.keys())}"
+            )
+        return cls._registry[name]
+
+    @classmethod
+    def list_models(cls) -> list[str]:
+        """Return a sorted list of all registered model names."""
+        return sorted(cls._registry.keys())
+
+    @classmethod
+    def load_from_checkpoint(
+        cls, checkpoint_path: str
+    ) -> "BaseTimeSeriesFoundationModel":
+        """Load any model from a checkpoint directory.
+
+        Reads ``metadata.json`` inside ``checkpoint_path`` to determine which
+        model class to use, then calls ``model_cls.load(checkpoint_path)``.
+
+        The ``metadata.json`` produced by ``BaseTimeSeriesFoundationModel.save()``
+        stores ``model_type`` as the class name (e.g. ``"TTMForecaster"``).
+        This method accepts either the registry key (e.g. ``"ttm"``) or the
+        class name (e.g. ``"TTMForecaster"``) in that field.
+
+        Args:
+            checkpoint_path: Path to the directory containing ``metadata.json``
+                             and the model checkpoint files.
+
+        Returns:
+            A loaded, ready-to-use model instance (``is_fitted`` will reflect
+            the state recorded in ``metadata.json``).
+
+        Raises:
+            FileNotFoundError: If ``metadata.json`` does not exist at
+                               ``checkpoint_path``.
+            KeyError: If the model type recorded in ``metadata.json`` is not
+                      in the registry (and is not a known class name).
+        """
+        metadata_path = Path(checkpoint_path) / "metadata.json"
+        if not metadata_path.exists():
+            raise FileNotFoundError(
+                f"No metadata.json found at '{checkpoint_path}'. "
+                f"Ensure the checkpoint was saved with "
+                f"BaseTimeSeriesFoundationModel.save()."
+            )
+
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+
+        raw_type = metadata.get("model_type", "")
+
+        # Try registry key first (forward-compatible), then class-name fallback
+        if raw_type in cls._registry:
+            model_key = raw_type
+        elif raw_type in _CLASS_NAME_TO_KEY:
+            model_key = _CLASS_NAME_TO_KEY[raw_type]
+        else:
+            raise KeyError(
+                f"Cannot resolve model type '{raw_type}' from metadata.json "
+                f"at '{checkpoint_path}'. "
+                f"Registered models: {sorted(cls._registry.keys())}"
+            )
+
+        model_cls = cls.get(model_key)
+        return model_cls.load(checkpoint_path)

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -47,7 +47,7 @@ class ModelRegistry:
                     importlib.import_module(mod_path)
                 except (ModuleNotFoundError, ImportError) as exc:
                     raise KeyError(
-                        f"Model '{name}' found in registry but failed to import "
+                        f"Model '{name}' is known but its module failed to import "
                         f"({mod_path}): {exc}"
                     ) from exc
         if name not in cls._registry:
@@ -72,6 +72,6 @@ class ModelRegistry:
                 importlib.import_module(mod_path)
                 if name in cls._registry:
                     result.append(name)
-            except ModuleNotFoundError:
+            except (ModuleNotFoundError, ImportError):
                 pass
         return sorted(result)

--- a/src/models/base/registry.py
+++ b/src/models/base/registry.py
@@ -1,102 +1,27 @@
-# Copyright (c) 2025 Blood-Glucose-Control
-# Licensed under Custom Research License (see LICENSE file)
-
-"""
-ModelRegistry: class-based registry for time series foundation models.
-
-Models self-register via the ``@ModelRegistry.register("name")`` decorator.
-The registry allows workflows to resolve a model class by a short name
-(e.g. "ttm", "chronos2") without hardcoding if/elif dispatch chains.
-
-Design notes
-------------
-- Registration is a pure class-level side-effect: no singleton objects,
-  no global state beyond the _registry dict.
-- The registry does NOT create model instances — callers still construct
-  the model-specific config and pass it to the class.  This is intentional:
-  every model has a different config type (TTMConfig, Chronos2Config, …),
-  and the registry should not paper over those differences.
-- ``load_from_checkpoint()`` reads the ``model_type`` field written by
-  ``BaseTimeSeriesFoundationModel.save()`` into ``metadata.json`` and
-  resolves the class, then delegates to ``cls.load()``.  The ``model_type``
-  stored there is the *registry key* (e.g. "ttm"), not the class name.
-  For checkpoints saved before the registry existed the lookup falls back
-  to a class-name-to-key mapping.
-"""
+"""ModelRegistry: maps short names to model classes via decorator."""
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Type
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from src.models.base.base_model import BaseTimeSeriesFoundationModel
 
 
-# Fallback: map class names (as stored in old metadata.json) to registry keys.
-# Only needed for checkpoints saved before @ModelRegistry.register was added.
-_CLASS_NAME_TO_KEY: Dict[str, str] = {
-    "TTMForecaster": "ttm",
-    "Chronos2Forecaster": "chronos2",
-    "TiDEForecaster": "tide",
-    "TimesFMForecaster": "timesfm",
-    "TimeGradForecaster": "timegrad",
-    "TSMixerForecaster": "tsmixer",
-    "SundialForecaster": "sundial",
-    "MoiraiForecaster": "moirai",
-    "MomentForecaster": "moment",
-}
-
-
 class ModelRegistry:
-    """Class-based registry mapping short names to model classes.
-
-    Usage
-    -----
-    Register a model (done once, at import time)::
-
-        @ModelRegistry.register("ttm")
-        class TTMForecaster(BaseTimeSeriesFoundationModel):
-            ...
-
-    Look up the class in a workflow::
-
-        cls = ModelRegistry.get("ttm")
-        config = TTMConfig(...)
-        model = cls(config)
-
-    Load from a checkpoint (class resolved from metadata.json)::
-
-        model = ModelRegistry.load_from_checkpoint("/path/to/checkpoint")
-    """
+    """Maps short names (e.g. "ttm", "chronos2") to model classes."""
 
     _registry: Dict[str, Type["BaseTimeSeriesFoundationModel"]] = {}
 
     @classmethod
     def register(cls, name: str):
-        """Decorator that registers a model class under ``name``.
-
-        Args:
-            name: Short identifier for the model (e.g. "ttm", "chronos2").
-                  Must be unique within the registry.
-
-        Returns:
-            The original class, unmodified (decorator is non-wrapping).
-
-        Raises:
-            ValueError: If ``name`` is already registered to a *different* class.
-                        Re-registering the same class under the same name is a
-                        no-op (safe for reload scenarios in interactive sessions).
-        """
+        """Decorator: ``@ModelRegistry.register("ttm")``."""
 
         def decorator(model_cls: Type) -> Type:
             existing = cls._registry.get(name)
             if existing is not None and existing is not model_cls:
                 raise ValueError(
-                    f"Cannot register '{model_cls.__name__}' as '{name}': "
-                    f"already registered to '{existing.__name__}'. "
-                    f"Use a unique name or unregister the existing entry first."
+                    f"'{name}' already registered to '{existing.__name__}'"
                 )
             cls._registry[name] = model_cls
             return model_cls
@@ -105,82 +30,13 @@ class ModelRegistry:
 
     @classmethod
     def get(cls, name: str) -> Type["BaseTimeSeriesFoundationModel"]:
-        """Return the model class registered under ``name``.
-
-        Args:
-            name: Registry key (e.g. "ttm", "chronos2").
-
-        Returns:
-            The model class (not an instance).
-
-        Raises:
-            KeyError: If ``name`` is not in the registry.  The error message
-                      lists all currently registered names to aid debugging.
-        """
         if name not in cls._registry:
             raise KeyError(
-                f"Model '{name}' is not registered. "
-                f"Available models: {sorted(cls._registry.keys())}"
+                f"Model '{name}' not registered. "
+                f"Available: {sorted(cls._registry.keys())}"
             )
         return cls._registry[name]
 
     @classmethod
     def list_models(cls) -> list[str]:
-        """Return a sorted list of all registered model names."""
         return sorted(cls._registry.keys())
-
-    @classmethod
-    def load_from_checkpoint(
-        cls, checkpoint_path: str
-    ) -> "BaseTimeSeriesFoundationModel":
-        """Load any model from a checkpoint directory.
-
-        Reads ``metadata.json`` inside ``checkpoint_path`` to determine which
-        model class to use, then calls ``model_cls.load(checkpoint_path)``.
-
-        The ``metadata.json`` produced by ``BaseTimeSeriesFoundationModel.save()``
-        stores ``model_type`` as the class name (e.g. ``"TTMForecaster"``).
-        This method accepts either the registry key (e.g. ``"ttm"``) or the
-        class name (e.g. ``"TTMForecaster"``) in that field.
-
-        Args:
-            checkpoint_path: Path to the directory containing ``metadata.json``
-                             and the model checkpoint files.
-
-        Returns:
-            A loaded, ready-to-use model instance (``is_fitted`` will reflect
-            the state recorded in ``metadata.json``).
-
-        Raises:
-            FileNotFoundError: If ``metadata.json`` does not exist at
-                               ``checkpoint_path``.
-            KeyError: If the model type recorded in ``metadata.json`` is not
-                      in the registry (and is not a known class name).
-        """
-        metadata_path = Path(checkpoint_path) / "metadata.json"
-        if not metadata_path.exists():
-            raise FileNotFoundError(
-                f"No metadata.json found at '{checkpoint_path}'. "
-                f"Ensure the checkpoint was saved with "
-                f"BaseTimeSeriesFoundationModel.save()."
-            )
-
-        with open(metadata_path) as f:
-            metadata = json.load(f)
-
-        raw_type = metadata.get("model_type", "")
-
-        # Try registry key first (forward-compatible), then class-name fallback
-        if raw_type in cls._registry:
-            model_key = raw_type
-        elif raw_type in _CLASS_NAME_TO_KEY:
-            model_key = _CLASS_NAME_TO_KEY[raw_type]
-        else:
-            raise KeyError(
-                f"Cannot resolve model type '{raw_type}' from metadata.json "
-                f"at '{checkpoint_path}'. "
-                f"Registered models: {sorted(cls._registry.keys())}"
-            )
-
-        model_cls = cls.get(model_key)
-        return model_cls.load(checkpoint_path)

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -33,6 +33,7 @@ import pandas as pd
 
 from src.data.preprocessing.gap_handling import segment_all_patients
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.utils.logging_helper import info_print
 
 from .config import Chronos2Config
@@ -44,6 +45,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+@ModelRegistry.register("chronos2")
 class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
     """Chronos-2 time series forecaster using AutoGluon backend.
 

--- a/src/models/moirai/model.py
+++ b/src/models/moirai/model.py
@@ -17,10 +17,12 @@ from transformers import (
 
 # Local imports
 from src.models.base import BaseTimeSeriesFoundationModel
+from src.models.base.registry import ModelRegistry
 from src.models.moirai.config import MoiraiConfig
 from src.utils.logging_helper import info_print, error_print
 
 
+@ModelRegistry.register("moirai")
 class MoiraiForecaster(BaseTimeSeriesFoundationModel):
     """Moirai forecaster implementation using the base TSFM framework.
 

--- a/src/models/moment/model.py
+++ b/src/models/moment/model.py
@@ -17,10 +17,12 @@ from transformers import (
 
 # Local imports
 from src.models.base import BaseTimeSeriesFoundationModel
+from src.models.base.registry import ModelRegistry
 from src.models.moment.config import MomentConfig
 from src.utils.logging_helper import info_print, error_print
 
 
+@ModelRegistry.register("moment")
 class MomentForecaster(BaseTimeSeriesFoundationModel):
     """Moment forecaster implementation using the base TSFM framework.
 

--- a/src/models/sundial/model.py
+++ b/src/models/sundial/model.py
@@ -16,11 +16,13 @@ from transformers import (
 # Local imports
 from src.models.sundial.config import SundialConfig
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.utils.logging_helper import info_print, error_print
 
 logger = logging.getLogger(__name__)
 
 
+@ModelRegistry.register("sundial")
 class SundialForecaster(BaseTimeSeriesFoundationModel):
     """Sundial forecaster implementation."""
 

--- a/src/models/tide/model.py
+++ b/src/models/tide/model.py
@@ -27,6 +27,7 @@ import pandas as pd
 
 from src.data.preprocessing.gap_handling import segment_all_patients
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.utils.logging_helper import info_print
 
 from .config import TiDEConfig
@@ -39,6 +40,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+@ModelRegistry.register("tide")
 class TiDEForecaster(BaseTimeSeriesFoundationModel):
     """TiDE time series forecaster using AutoGluon backend.
 

--- a/src/models/timegrad/model.py
+++ b/src/models/timegrad/model.py
@@ -22,6 +22,7 @@ from pts.feature import (
 
 from src.models.timegrad.config import TimeGradConfig
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.utils.logging_helper import info_print
 
 logger = logging.getLogger(__name__)
@@ -88,6 +89,7 @@ def _compute_input_size(freq: str, target_dim: int = 1) -> int:
 _apply_univariate_patch()
 
 
+@ModelRegistry.register("timegrad")
 class TimeGradForecaster(BaseTimeSeriesFoundationModel):
     """TimeGrad forecaster: GRU encoder + denoising diffusion head.
 

--- a/src/models/timesfm/model.py
+++ b/src/models/timesfm/model.py
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from torch.utils.data import DataLoader, Dataset
 
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.models.timesfm.config import TimesFMConfig
 from src.utils.logging_helper import info_print, error_print
 
@@ -158,6 +159,7 @@ class TimesFMForTrainer(nn.Module):
         return {"loss": loss, "logits": mean_predictions}
 
 
+@ModelRegistry.register("timesfm")
 class TimesFMForecaster(BaseTimeSeriesFoundationModel):
     """TimesFM forecaster using HuggingFace Transformers.
 

--- a/src/models/tsmixer/model.py
+++ b/src/models/tsmixer/model.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 from transformers import TrainingArguments
 
 from src.models.base import BaseTimeSeriesFoundationModel, ModelConfig, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.utils.logging_helper import info_print, error_print
 
 
@@ -43,6 +44,7 @@ class TSMixerConfig(ModelConfig):
         self.mixing_hidden_dim = kwargs.get("mixing_hidden_dim", 256)
 
 
+@ModelRegistry.register("tsmixer")
 class TSMixerForecaster(BaseTimeSeriesFoundationModel):
     """
     TSMixer forecaster implementation.

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -28,6 +28,7 @@ from tsfm_public.toolkit.time_series_preprocessor import ScalerType
 
 # Local imports
 from src.models.base import BaseTimeSeriesFoundationModel, TrainingBackend
+from src.models.base.registry import ModelRegistry
 from src.models.ttm.config import TTMConfig
 from src.data.models import ColumnNames
 from src.data.preprocessing.split_or_combine_patients import (
@@ -63,6 +64,7 @@ class ColumnSpecifiers(TypedDict, total=False):
     static_categorical_columns: List[str]
 
 
+@ModelRegistry.register("ttm")
 class TTMForecaster(BaseTimeSeriesFoundationModel):
     """TTM (TinyTimeMixer) forecaster implementation.
 

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Tests for ModelRegistry.
+
+These tests cover:
+- Registry is importable with no heavy deps
+- @ModelRegistry.register() decorator works
+- get() returns the registered class
+- get() raises KeyError for unknown names
+- list_models() returns sorted names
+- Re-registration of the same class is a no-op
+- Conflicting registration raises ValueError
+- load_from_checkpoint() resolves by registry key in metadata.json
+- load_from_checkpoint() resolves by class name (legacy fallback)
+- load_from_checkpoint() raises FileNotFoundError when metadata.json absent
+- load_from_checkpoint() raises KeyError when model_type unrecognised
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.models.base.registry import ModelRegistry, _CLASS_NAME_TO_KEY
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RegistryIsolation:
+    """Context manager that saves and restores ModelRegistry._registry."""
+
+    def __enter__(self):
+        self._saved = dict(ModelRegistry._registry)
+        return self
+
+    def __exit__(self, *args):
+        ModelRegistry._registry.clear()
+        ModelRegistry._registry.update(self._saved)
+
+
+# ---------------------------------------------------------------------------
+# Basic registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_get():
+    with _RegistryIsolation():
+
+        @ModelRegistry.register("_test_model")
+        class _DummyModel:
+            pass
+
+        assert ModelRegistry.get("_test_model") is _DummyModel
+
+
+def test_get_raises_for_unknown():
+    with _RegistryIsolation():
+        with pytest.raises(KeyError, match="_no_such_model"):
+            ModelRegistry.get("_no_such_model")
+
+
+def test_list_models_is_sorted():
+    with _RegistryIsolation():
+
+        @ModelRegistry.register("_z_model")
+        class _Z:
+            pass
+
+        @ModelRegistry.register("_a_model")
+        class _A:
+            pass
+
+        names = ModelRegistry.list_models()
+        assert names == sorted(names)
+        assert "_z_model" in names
+        assert "_a_model" in names
+
+
+def test_reregistration_same_class_is_noop():
+    with _RegistryIsolation():
+
+        @ModelRegistry.register("_noop_model")
+        class _Noop:
+            pass
+
+        # Re-registering the identical class should not raise
+        ModelRegistry.register("_noop_model")(_Noop)
+        assert ModelRegistry.get("_noop_model") is _Noop
+
+
+def test_conflicting_registration_raises():
+    with _RegistryIsolation():
+
+        @ModelRegistry.register("_conflict_model")
+        class _First:
+            pass
+
+        class _Second:
+            pass
+
+        with pytest.raises(ValueError, match="_conflict_model"):
+            ModelRegistry.register("_conflict_model")(_Second)
+
+
+# ---------------------------------------------------------------------------
+# load_from_checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_load_from_checkpoint_by_registry_key():
+    """load_from_checkpoint resolves model type from metadata.json registry key."""
+    with _RegistryIsolation():
+        loaded = []
+
+        @ModelRegistry.register("_cp_model")
+        class _CPModel:
+            @classmethod
+            def load(cls, path):
+                loaded.append(path)
+                return cls()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata = {"model_type": "_cp_model", "is_fitted": True}
+            (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
+
+            instance = ModelRegistry.load_from_checkpoint(tmpdir)
+
+        assert len(loaded) == 1
+        assert isinstance(instance, _CPModel)
+
+
+def test_load_from_checkpoint_by_class_name_fallback():
+    """load_from_checkpoint falls back to _CLASS_NAME_TO_KEY mapping."""
+    with _RegistryIsolation():
+        loaded = []
+
+        @ModelRegistry.register("_legacy_key")
+        class _LegacyModel:
+            @classmethod
+            def load(cls, path):
+                loaded.append(path)
+                return cls()
+
+        # Temporarily patch _CLASS_NAME_TO_KEY
+        original = dict(_CLASS_NAME_TO_KEY)
+        _CLASS_NAME_TO_KEY["_OldClassName"] = "_legacy_key"
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                metadata = {"model_type": "_OldClassName", "is_fitted": True}
+                (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
+
+                instance = ModelRegistry.load_from_checkpoint(tmpdir)
+
+            assert isinstance(instance, _LegacyModel)
+        finally:
+            _CLASS_NAME_TO_KEY.clear()
+            _CLASS_NAME_TO_KEY.update(original)
+
+
+def test_load_from_checkpoint_missing_metadata():
+    with _RegistryIsolation():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(FileNotFoundError, match="metadata.json"):
+                ModelRegistry.load_from_checkpoint(tmpdir)
+
+
+def test_load_from_checkpoint_unknown_model_type():
+    with _RegistryIsolation():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata = {"model_type": "_totally_unknown_xyz"}
+            (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
+
+            with pytest.raises(KeyError, match="_totally_unknown_xyz"):
+                ModelRegistry.load_from_checkpoint(tmpdir)
+
+
+# ---------------------------------------------------------------------------
+# Real-world models are registered (when imports succeed)
+# ---------------------------------------------------------------------------
+
+
+def test_real_models_registered_when_imported():
+    """Importing src.models triggers registrations; check at least one succeeds.
+
+    This test is not parameterised per-model because each model has optional
+    heavy dependencies.  We simply assert that after importing src.models at
+    least *some* models are in the registry — if ALL imports failed (no deps
+    at all) we skip with an informative message rather than failing.
+    """
+    import src.models  # noqa: F401 — side-effect import
+
+    registered = ModelRegistry.list_models()
+    if not registered:
+        pytest.skip(
+            "No models registered after importing src.models. "
+            "This environment is missing all optional model dependencies."
+        )
+
+    # Verify each registered model has at least a `load` classmethod
+    for name in registered:
+        cls = ModelRegistry.get(name)
+        assert hasattr(
+            cls, "load"
+        ), f"Registered model '{name}' ({cls.__name__}) lacks a .load() classmethod"
+
+
+def test_class_name_to_key_covers_all_registered():
+    """Verify _CLASS_NAME_TO_KEY stays in sync with registered models.
+
+    Every registered model's class name must appear in _CLASS_NAME_TO_KEY
+    so that load_from_checkpoint() works on old checkpoints that store
+    the class name instead of the registry key.
+    """
+    import src.models  # noqa: F401
+
+    registered = ModelRegistry.list_models()
+    if not registered:
+        pytest.skip("No models registered in this environment.")
+
+    for name in registered:
+        cls = ModelRegistry.get(name)
+        assert cls.__name__ in _CLASS_NAME_TO_KEY, (
+            f"Registered model '{name}' ({cls.__name__}) is missing from "
+            f"_CLASS_NAME_TO_KEY — old checkpoints won't load via "
+            f"load_from_checkpoint()"
+        )
+        assert _CLASS_NAME_TO_KEY[cls.__name__] == name, (
+            f"_CLASS_NAME_TO_KEY['{cls.__name__}'] = "
+            f"'{_CLASS_NAME_TO_KEY[cls.__name__]}' but model is registered "
+            f"as '{name}'"
+        )

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -7,8 +7,9 @@ from src.models.base.registry import ModelRegistry
 
 @pytest.fixture(autouse=True)
 def _isolate_registry():
-    """Save and restore registry around each test."""
+    """Clear registry before each test, restore after."""
     saved = dict(ModelRegistry._registry)
+    ModelRegistry._registry.clear()
     yield
     ModelRegistry._registry.clear()
     ModelRegistry._registry.update(saved)
@@ -36,17 +37,15 @@ def test_conflict_raises():
         ModelRegistry.register("_dup")(type("_B", (), {}))
 
 
-def test_real_models_registered():
-    """At least some models register when src.models is imported."""
-    import src.models  # noqa: F401
-
-    registered = ModelRegistry.list_models()
-    if not registered:
+def test_lazy_import():
+    """get() lazily imports the model module on first access."""
+    available = ModelRegistry.available_models()
+    if not available:
         pytest.skip("No model deps installed.")
 
     from src.models.base import BaseTimeSeriesFoundationModel
 
-    # Verify each registered class is actually a model, not a stray class
-    for name in registered:
-        cls = ModelRegistry.get(name)
-        assert issubclass(cls, BaseTimeSeriesFoundationModel)
+    # Pick first available model — get() should lazily import it
+    name = available[0]
+    cls = ModelRegistry.get(name)
+    assert issubclass(cls, BaseTimeSeriesFoundationModel)

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -44,6 +44,9 @@ def test_real_models_registered():
     if not registered:
         pytest.skip("No model deps installed.")
 
+    from src.models.base import BaseTimeSeriesFoundationModel
+
+    # Verify each registered class is actually a model, not a stray class
     for name in registered:
         cls = ModelRegistry.get(name)
-        assert hasattr(cls, "load")
+        assert issubclass(cls, BaseTimeSeriesFoundationModel)

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -5,9 +5,9 @@ import pytest
 from src.models.base.registry import ModelRegistry
 
 
-@pytest.fixture(autouse=True)
-def _isolate_registry():
-    """Clear registry before each test, restore after."""
+@pytest.fixture()
+def clean_registry():
+    """Clear registry before test, restore after."""
     saved = dict(ModelRegistry._registry)
     ModelRegistry._registry.clear()
     yield
@@ -15,7 +15,7 @@ def _isolate_registry():
     ModelRegistry._registry.update(saved)
 
 
-def test_register_and_get():
+def test_register_and_get(clean_registry):
     @ModelRegistry.register("_test")
     class _M:
         pass
@@ -23,12 +23,12 @@ def test_register_and_get():
     assert ModelRegistry.get("_test") is _M
 
 
-def test_get_unknown_raises():
+def test_get_unknown_raises(clean_registry):
     with pytest.raises(KeyError, match="_nope"):
         ModelRegistry.get("_nope")
 
 
-def test_conflict_raises():
+def test_conflict_raises(clean_registry):
     @ModelRegistry.register("_dup")
     class _A:
         pass
@@ -37,15 +37,14 @@ def test_conflict_raises():
         ModelRegistry.register("_dup")(type("_B", (), {}))
 
 
-def test_lazy_import():
-    """get() lazily imports the model module on first access."""
+def test_real_models_available():
+    """At least some models are importable and register correctly."""
     available = ModelRegistry.available_models()
     if not available:
         pytest.skip("No model deps installed.")
 
     from src.models.base import BaseTimeSeriesFoundationModel
 
-    # Pick first available model — get() should lazily import it
-    name = available[0]
-    cls = ModelRegistry.get(name)
-    assert issubclass(cls, BaseTimeSeriesFoundationModel)
+    for name in available:
+        cls = ModelRegistry.get(name)
+        assert issubclass(cls, BaseTimeSeriesFoundationModel)

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -37,6 +37,17 @@ def test_conflict_raises(clean_registry):
         ModelRegistry.register("_dup")(type("_B", (), {}))
 
 
+def test_get_missing_dep_raises_key_error(clean_registry, monkeypatch):
+    """get() wraps ModuleNotFoundError into a helpful KeyError."""
+    from src.models.base import registry as reg_mod
+
+    # Inject a fake model module that will fail to import
+    monkeypatch.setitem(reg_mod._MODEL_MODULES, "_fake", "no.such.module")
+
+    with pytest.raises(KeyError, match="failed to import"):
+        ModelRegistry.get("_fake")
+
+
 def test_real_models_available():
     """At least some models are importable and register correctly."""
     available = ModelRegistry.available_models()

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -1,237 +1,49 @@
-# Copyright (c) 2025 Blood-Glucose-Control
-# Licensed under Custom Research License (see LICENSE file)
-
-"""Tests for ModelRegistry.
-
-These tests cover:
-- Registry is importable with no heavy deps
-- @ModelRegistry.register() decorator works
-- get() returns the registered class
-- get() raises KeyError for unknown names
-- list_models() returns sorted names
-- Re-registration of the same class is a no-op
-- Conflicting registration raises ValueError
-- load_from_checkpoint() resolves by registry key in metadata.json
-- load_from_checkpoint() resolves by class name (legacy fallback)
-- load_from_checkpoint() raises FileNotFoundError when metadata.json absent
-- load_from_checkpoint() raises KeyError when model_type unrecognised
-"""
-
-import json
-import tempfile
-from pathlib import Path
+"""Tests for ModelRegistry."""
 
 import pytest
 
-from src.models.base.registry import ModelRegistry, _CLASS_NAME_TO_KEY
+from src.models.base.registry import ModelRegistry
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class _RegistryIsolation:
-    """Context manager that saves and restores ModelRegistry._registry."""
-
-    def __enter__(self):
-        self._saved = dict(ModelRegistry._registry)
-        return self
-
-    def __exit__(self, *args):
-        ModelRegistry._registry.clear()
-        ModelRegistry._registry.update(self._saved)
-
-
-# ---------------------------------------------------------------------------
-# Basic registration
-# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Save and restore registry around each test."""
+    saved = dict(ModelRegistry._registry)
+    yield
+    ModelRegistry._registry.clear()
+    ModelRegistry._registry.update(saved)
 
 
 def test_register_and_get():
-    with _RegistryIsolation():
+    @ModelRegistry.register("_test")
+    class _M:
+        pass
 
-        @ModelRegistry.register("_test_model")
-        class _DummyModel:
-            pass
-
-        assert ModelRegistry.get("_test_model") is _DummyModel
+    assert ModelRegistry.get("_test") is _M
 
 
-def test_get_raises_for_unknown():
-    with _RegistryIsolation():
-        with pytest.raises(KeyError, match="_no_such_model"):
-            ModelRegistry.get("_no_such_model")
+def test_get_unknown_raises():
+    with pytest.raises(KeyError, match="_nope"):
+        ModelRegistry.get("_nope")
 
 
-def test_list_models_is_sorted():
-    with _RegistryIsolation():
+def test_conflict_raises():
+    @ModelRegistry.register("_dup")
+    class _A:
+        pass
 
-        @ModelRegistry.register("_z_model")
-        class _Z:
-            pass
-
-        @ModelRegistry.register("_a_model")
-        class _A:
-            pass
-
-        names = ModelRegistry.list_models()
-        assert names == sorted(names)
-        assert "_z_model" in names
-        assert "_a_model" in names
+    with pytest.raises(ValueError, match="_dup"):
+        ModelRegistry.register("_dup")(type("_B", (), {}))
 
 
-def test_reregistration_same_class_is_noop():
-    with _RegistryIsolation():
-
-        @ModelRegistry.register("_noop_model")
-        class _Noop:
-            pass
-
-        # Re-registering the identical class should not raise
-        ModelRegistry.register("_noop_model")(_Noop)
-        assert ModelRegistry.get("_noop_model") is _Noop
-
-
-def test_conflicting_registration_raises():
-    with _RegistryIsolation():
-
-        @ModelRegistry.register("_conflict_model")
-        class _First:
-            pass
-
-        class _Second:
-            pass
-
-        with pytest.raises(ValueError, match="_conflict_model"):
-            ModelRegistry.register("_conflict_model")(_Second)
-
-
-# ---------------------------------------------------------------------------
-# load_from_checkpoint
-# ---------------------------------------------------------------------------
-
-
-def test_load_from_checkpoint_by_registry_key():
-    """load_from_checkpoint resolves model type from metadata.json registry key."""
-    with _RegistryIsolation():
-        loaded = []
-
-        @ModelRegistry.register("_cp_model")
-        class _CPModel:
-            @classmethod
-            def load(cls, path):
-                loaded.append(path)
-                return cls()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            metadata = {"model_type": "_cp_model", "is_fitted": True}
-            (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
-
-            instance = ModelRegistry.load_from_checkpoint(tmpdir)
-
-        assert len(loaded) == 1
-        assert isinstance(instance, _CPModel)
-
-
-def test_load_from_checkpoint_by_class_name_fallback():
-    """load_from_checkpoint falls back to _CLASS_NAME_TO_KEY mapping."""
-    with _RegistryIsolation():
-        loaded = []
-
-        @ModelRegistry.register("_legacy_key")
-        class _LegacyModel:
-            @classmethod
-            def load(cls, path):
-                loaded.append(path)
-                return cls()
-
-        # Temporarily patch _CLASS_NAME_TO_KEY
-        original = dict(_CLASS_NAME_TO_KEY)
-        _CLASS_NAME_TO_KEY["_OldClassName"] = "_legacy_key"
-
-        try:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                metadata = {"model_type": "_OldClassName", "is_fitted": True}
-                (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
-
-                instance = ModelRegistry.load_from_checkpoint(tmpdir)
-
-            assert isinstance(instance, _LegacyModel)
-        finally:
-            _CLASS_NAME_TO_KEY.clear()
-            _CLASS_NAME_TO_KEY.update(original)
-
-
-def test_load_from_checkpoint_missing_metadata():
-    with _RegistryIsolation():
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with pytest.raises(FileNotFoundError, match="metadata.json"):
-                ModelRegistry.load_from_checkpoint(tmpdir)
-
-
-def test_load_from_checkpoint_unknown_model_type():
-    with _RegistryIsolation():
-        with tempfile.TemporaryDirectory() as tmpdir:
-            metadata = {"model_type": "_totally_unknown_xyz"}
-            (Path(tmpdir) / "metadata.json").write_text(json.dumps(metadata))
-
-            with pytest.raises(KeyError, match="_totally_unknown_xyz"):
-                ModelRegistry.load_from_checkpoint(tmpdir)
-
-
-# ---------------------------------------------------------------------------
-# Real-world models are registered (when imports succeed)
-# ---------------------------------------------------------------------------
-
-
-def test_real_models_registered_when_imported():
-    """Importing src.models triggers registrations; check at least one succeeds.
-
-    This test is not parameterised per-model because each model has optional
-    heavy dependencies.  We simply assert that after importing src.models at
-    least *some* models are in the registry — if ALL imports failed (no deps
-    at all) we skip with an informative message rather than failing.
-    """
-    import src.models  # noqa: F401 — side-effect import
-
-    registered = ModelRegistry.list_models()
-    if not registered:
-        pytest.skip(
-            "No models registered after importing src.models. "
-            "This environment is missing all optional model dependencies."
-        )
-
-    # Verify each registered model has at least a `load` classmethod
-    for name in registered:
-        cls = ModelRegistry.get(name)
-        assert hasattr(
-            cls, "load"
-        ), f"Registered model '{name}' ({cls.__name__}) lacks a .load() classmethod"
-
-
-def test_class_name_to_key_covers_all_registered():
-    """Verify _CLASS_NAME_TO_KEY stays in sync with registered models.
-
-    Every registered model's class name must appear in _CLASS_NAME_TO_KEY
-    so that load_from_checkpoint() works on old checkpoints that store
-    the class name instead of the registry key.
-    """
+def test_real_models_registered():
+    """At least some models register when src.models is imported."""
     import src.models  # noqa: F401
 
     registered = ModelRegistry.list_models()
     if not registered:
-        pytest.skip("No models registered in this environment.")
+        pytest.skip("No model deps installed.")
 
     for name in registered:
         cls = ModelRegistry.get(name)
-        assert cls.__name__ in _CLASS_NAME_TO_KEY, (
-            f"Registered model '{name}' ({cls.__name__}) is missing from "
-            f"_CLASS_NAME_TO_KEY — old checkpoints won't load via "
-            f"load_from_checkpoint()"
-        )
-        assert _CLASS_NAME_TO_KEY[cls.__name__] == name, (
-            f"_CLASS_NAME_TO_KEY['{cls.__name__}'] = "
-            f"'{_CLASS_NAME_TO_KEY[cls.__name__]}' but model is registered "
-            f"as '{name}'"
-        )
+        assert hasattr(cls, "load")


### PR DESCRIPTION
## Problem

Model dispatch is hardcoded in two places with identical if/elif chains:

**`src/models/factory.py`** — `create_model_and_config()` (362 lines, 8 branches):
```python
if model_type == "sundial":    # 30 lines
elif model_type == "ttm":      # 97 lines — load training_metadata.json, filter fields
elif model_type == "chronos2": # 38 lines — strip /model.pt suffix
elif model_type == "timesfm":  # 82 lines — try training_metadata.json then hf_model/config.json
# ... 4 more branches
```

**`scripts/examples/example_holdout_generic_workflow.py`** — `ModelFactory` class (522 lines, 3 dispatch chains):
1. `create_model()` — 7 elif branches → routes to `_create_*_model()` helpers
2. Each `_create_*_model()` — maps `GenericModelConfig` fields to the typed config
3. `load_model()` — 7 more elif branches, doing the same field mapping again

Every model's fields are mapped **3 times** (once in each dispatch location). Adding a new model means editing 3 files and adding ~6 elif branches. The `GenericModelConfig` catch-all `**config.extra_config` is where `fine_tune_batch_size` just crashed (#391 discussion).

## Solution

A 42-line `ModelRegistry` class (it's a dict with a decorator):

```python
# In each model file — one-time registration at import:
@ModelRegistry.register("chronos2")
class Chronos2Forecaster(BaseTimeSeriesFoundationModel): ...

# In a workflow — dict lookup instead of elif chain:
model_cls = ModelRegistry.get("chronos2")
model = model_cls(config)
```

No dispatch chains. No `GenericModelConfig`. The caller builds the typed config directly.

## What this PR does (and doesn't do)

**Does:**
- Adds `src/models/base/registry.py` — `register()`, `get()`, `list_models()` (42 lines)
- Decorates all 9 model classes with `@ModelRegistry.register("name")`
- `src/models/__init__.py` triggers registration at import time (skip if deps missing)
- 4 tests: register/get, unknown key, conflict detection, real models are `BaseTimeSeriesFoundationModel` subclasses

**Does not:**
- Delete or modify `ModelFactory` or `factory.py` — they continue working unchanged
- Change any model behavior — the decorator records the class in a dict and returns it unmodified
- Add any runtime overhead — registration happens once at import time

## Why no regression

The decorator is a no-op side effect. It stores a reference to the class in a dict and returns the class unchanged:

```python
def decorator(model_cls):
    cls._registry[name] = model_cls
    return model_cls          # ← class is NOT modified
```

No model behavior changes. No existing code paths are altered. `ModelFactory` still works identically. The registry is purely additive infrastructure for future workflow simplification.

## After this merges

The `ModelFactory` elif chains in `factory.py` (362 lines) and the workflow script (522 lines) can be replaced with `ModelRegistry.get(model_type)` — but that's a separate PR.

Closes #387