### PR TITLE
Add joint co-target forecasting mode to Chronos-2

### DIFF
--- a/configs/models/chronos2/02_joint_bg_iob.yaml
+++ b/configs/models/chronos2/02_joint_bg_iob.yaml
@@ -24,8 +24,8 @@ fine_tune_steps: 15000
 fine_tune_lr: 1.0e-5
 
 # Joint co-target mode: both columns become separate panel items.
-# covariate_cols is ignored when target_cols has >1 entry.
-target_cols: ["bg_mM", "iob"]
+# covariate_cols is ignored when joint_target_cols has >1 entry.
+joint_target_cols: ["bg_mM", "iob"]
 target_col: "bg_mM"
 patient_col: "p_num"
 time_col: "datetime"

--- a/configs/models/chronos2/03_joint_bg_iob.yaml
+++ b/configs/models/chronos2/03_joint_bg_iob.yaml
@@ -1,0 +1,35 @@
+# =============================================================================
+# Chronos-2 — Joint BG + IOB co-target forecasting
+# =============================================================================
+# Multi-target mode: BG and IOB are stacked as separate items in the
+# AutoGluon panel (long-format). The model trains jointly on both via
+# shared Chronos-2 weights. At inference, only BG predictions are returned.
+#
+# Compare against 01_bg_iob_insulin_availability.yaml (covariate mode) to
+# measure the effect of joint training vs past-only covariate context.
+#
+# Usage:
+#   sbatch scripts/training/slurm/chronos2_finetune.sh \
+#     MODEL_CONFIG=configs/models/chronos2/03_joint_bg_iob.yaml
+# =============================================================================
+
+model_path: "autogluon/chronos-2"
+context_length: 512
+forecast_length: 96  # 6 hours at 5-min intervals
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+fine_tune_steps: 15000
+fine_tune_lr: 1.0e-5
+
+# Joint co-target mode: both columns become separate panel items.
+# covariate_cols is ignored when target_cols has >1 entry.
+target_cols: ["bg_mM", "iob"]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5
+
+eval_metric: "RMSE"
+enable_ensemble: false

--- a/src/evaluation/nocturnal.py
+++ b/src/evaluation/nocturnal.py
@@ -102,12 +102,19 @@ def evaluate_nocturnal_forecasting(
                 )
                 continue
 
+        # In multi-target mode, target_cols (e.g. ["bg_mM", "iob"]) must be
+        # included as covariates so they appear in context_df for stacking.
+        effective_covs = list(covariate_cols) if covariate_cols else []
+        if hasattr(model, "config") and getattr(model.config, "is_multitarget", False):
+            for col in model.config.target_cols:
+                if col != target_col and col not in effective_covs:
+                    effective_covs.append(col)
         episodes, _ = build_midnight_episodes(
             patient_df,
             context_length=context_length,
             forecast_length=forecast_length,
             target_col=target_col,
-            covariate_cols=covariate_cols,
+            covariate_cols=effective_covs or None,
             interval_mins=interval_mins,
         )
 

--- a/src/evaluation/nocturnal.py
+++ b/src/evaluation/nocturnal.py
@@ -102,11 +102,11 @@ def evaluate_nocturnal_forecasting(
                 )
                 continue
 
-        # In multi-target mode, target_cols (e.g. ["bg_mM", "iob"]) must be
+        # In multi-target mode, joint_target_cols (e.g. ["bg_mM", "iob"]) must be
         # included as covariates so they appear in context_df for stacking.
         effective_covs = list(covariate_cols) if covariate_cols else []
         if hasattr(model, "config") and getattr(model.config, "is_multitarget", False):
-            for col in model.config.target_cols:
+            for col in getattr(model.config, "joint_target_cols", []):
                 if col != target_col and col not in effective_covs:
                     effective_covs.append(col)
         episodes, _ = build_midnight_episodes(

--- a/src/models/chronos2/config.py
+++ b/src/models/chronos2/config.py
@@ -64,13 +64,13 @@ class Chronos2Config(ModelConfig):
     # post-midnight reactive events). Defaults to ["iob"].
     covariate_cols: List[str] = field(default_factory=lambda: ["iob"])
     target_col: str = "bg_mM"
-    # Joint co-target mode: when target_cols has >1 entry, each column becomes
+    # Joint co-target mode: when joint_target_cols has >1 entry, each column becomes
     # a separate item in the AutoGluon panel (long-format stacking). The model
     # trains jointly on all targets via shared weights. At inference, only
     # target_col (primary target) predictions are returned.
     # Empty list = single-target mode (backward compatible, uses covariates).
     # covariate_cols are ignored in multi-target mode.
-    target_cols: List[str] = field(default_factory=list)
+    joint_target_cols: List[str] = field(default_factory=list)
     patient_col: str = "p_num"
     time_col: str = "datetime"
 
@@ -89,21 +89,21 @@ class Chronos2Config(ModelConfig):
     @property
     def is_multitarget(self) -> bool:
         """True when multiple target columns are configured (joint forecasting)."""
-        return len(self.target_cols) > 1
+        return len(self.joint_target_cols) > 1
 
     def __post_init__(self):
         if self.min_segment_length is None:
             self.min_segment_length = self.context_length + self.forecast_length
 
         # Validate multi-target config
-        if self.is_multitarget and self.target_col not in self.target_cols:
+        if self.is_multitarget and self.target_col not in self.joint_target_cols:
             raise ValueError(
-                f"target_col '{self.target_col}' must be in target_cols "
-                f"{self.target_cols} (it is the primary prediction target)"
+                f"target_col '{self.target_col}' must be in joint_target_cols "
+                f"{self.joint_target_cols} (it is the primary prediction target)"
             )
-        if len(self.target_cols) == 1:
+        if len(self.joint_target_cols) == 1:
             raise ValueError(
-                f"target_cols has 1 entry {self.target_cols}; use target_col "
+                f"joint_target_cols has 1 entry {self.joint_target_cols}; use target_col "
                 f"for single-target mode, or add more columns for joint mode"
             )
 

--- a/src/models/chronos2/config.py
+++ b/src/models/chronos2/config.py
@@ -64,6 +64,13 @@ class Chronos2Config(ModelConfig):
     # post-midnight reactive events). Defaults to ["iob"].
     covariate_cols: List[str] = field(default_factory=lambda: ["iob"])
     target_col: str = "bg_mM"
+    # Joint co-target mode: when target_cols has >1 entry, each column becomes
+    # a separate item in the AutoGluon panel (long-format stacking). The model
+    # trains jointly on all targets via shared weights. At inference, only
+    # target_col (primary target) predictions are returned.
+    # Empty list = single-target mode (backward compatible, uses covariates).
+    # covariate_cols are ignored in multi-target mode.
+    target_cols: List[str] = field(default_factory=list)
     patient_col: str = "p_num"
     time_col: str = "datetime"
 
@@ -79,9 +86,26 @@ class Chronos2Config(ModelConfig):
     # most windows naturally get full context regardless of this setting.
     min_past: int = 1
 
+    @property
+    def is_multitarget(self) -> bool:
+        """True when multiple target columns are configured (joint forecasting)."""
+        return len(self.target_cols) > 1
+
     def __post_init__(self):
         if self.min_segment_length is None:
             self.min_segment_length = self.context_length + self.forecast_length
+
+        # Validate multi-target config
+        if self.is_multitarget and self.target_col not in self.target_cols:
+            raise ValueError(
+                f"target_col '{self.target_col}' must be in target_cols "
+                f"{self.target_cols} (it is the primary prediction target)"
+            )
+        if len(self.target_cols) == 1:
+            raise ValueError(
+                f"target_cols has 1 entry {self.target_cols}; use target_col "
+                f"for single-target mode, or add more columns for joint mode"
+            )
 
     def get_autogluon_hyperparameters(self) -> Dict:
         """Build hyperparameters dict for TimeSeriesPredictor.fit().

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -135,10 +135,16 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
         )
         info_print(f"Gap handling: {len(segments)} segments")
 
-        # format for AutoGluon with covariates
-        ts_train = format_segments_for_autogluon(
-            segments, config.target_col, config.covariate_cols
-        )
+        # Multi-target mode: stack each target col as a separate item
+        if config.is_multitarget:
+            info_print(f"Multi-target mode: {config.target_cols}")
+            ts_train = format_segments_for_autogluon(
+                segments, target_cols=config.target_cols
+            )
+        else:
+            ts_train = format_segments_for_autogluon(
+                segments, config.target_col, config.covariate_cols
+            )
         info_print(f"Training data: {ts_train.shape}")
 
         return (ts_train, None, None)
@@ -248,6 +254,9 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
         renaming, and covariate column selection — the shared boilerplate
         required before calling ``self.predictor.predict()``.
 
+        In multi-target mode, each episode is stacked into N items (one per
+        target column), e.g. ``ep_0__bg_mM``, ``ep_0__iob``.
+
         Returns:
             TimeSeriesDataFrame ready for AutoGluon prediction.
         """
@@ -259,11 +268,44 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
         if "episode_id" not in context.columns:
             context["episode_id"] = "ep_0"
 
-        context["item_id"] = context["episode_id"]
         if config.time_col in context.columns:
             context["timestamp"] = pd.to_datetime(context[config.time_col])
         else:
             context["timestamp"] = context.index
+
+        # Multi-target mode: stack each target column as a separate item
+        if config.is_multitarget:
+            data_list = []
+            for ep_id in context["episode_id"].unique():
+                ep_data = context[context["episode_id"] == ep_id]
+                for col in config.target_cols:
+                    if col not in ep_data.columns:
+                        logger.warning(
+                            "Target column '%s' missing for episode %s", col, ep_id
+                        )
+                        continue
+                    # ffill short gaps; fillna(0) for leading NaNs
+                    # (0 is semantically correct for IOB; BG leading NaNs are rare)
+                    vals = ep_data[col].ffill().fillna(0)
+                    df = pd.DataFrame(
+                        {
+                            "item_id": f"{str(ep_id)}__{col}",
+                            "timestamp": ep_data["timestamp"].values,
+                            "target": vals.values,
+                        }
+                    )
+                    data_list.append(df)
+            if not data_list:
+                raise ValueError(
+                    f"No valid multi-target data found. Check that target_cols "
+                    f"{config.target_cols} exist in the input DataFrame."
+                )
+            combined = pd.concat(data_list, ignore_index=True)
+            combined = combined.set_index(["item_id", "timestamp"])
+            return TimeSeriesDataFrame(combined)
+
+        # Single-target mode
+        context["item_id"] = context["episode_id"].astype(str)
         context = context.rename(columns={config.target_col: "target"})
 
         ag_cols = ["item_id", "timestamp", "target"] + config.covariate_cols
@@ -277,6 +319,17 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
         if "episode_id" in data.columns:
             return data["episode_id"].unique()
         return np.array(["ep_0"])
+
+    def _ag_item_id(self, episode_id: str) -> str:
+        """Map an episode ID to the AutoGluon item_id used for extraction.
+
+        In multi-target mode, items are named ``{ep_id}__{col}`` and we
+        extract only the primary target column.  In single-target mode the
+        item_id equals the episode_id directly.
+        """
+        if self.config.is_multitarget:
+            return f"{episode_id}__{self.config.target_col}"
+        return episode_id
 
     def _zero_shot_forecast(self, data: pd.DataFrame, quantile_levels=None):
         """Run zero-shot inference via Chronos2Pipeline.
@@ -300,6 +353,10 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
     def _autogluon_extract(self, data: pd.DataFrame, columns: list) -> np.ndarray:
         """Run fine-tuned AutoGluon inference and extract specified columns.
 
+        In multi-target mode, all target columns are fed to the predictor but
+        only the primary target (``config.target_col``) predictions are
+        extracted via ``_ag_item_id()``.
+
         Args:
             data: Input DataFrame (same format as _predict).
             columns: Column names to extract from AutoGluon predictions,
@@ -316,9 +373,10 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
 
         result_arrays = []
         for episode_id in self._episode_ids_from(data):
-            if episode_id not in ag_predictions.index.get_level_values(0):
+            item_id = self._ag_item_id(episode_id)
+            if item_id not in ag_predictions.index.get_level_values(0):
                 continue
-            ep_preds = ag_predictions.loc[episode_id]
+            ep_preds = ag_predictions.loc[item_id]
             if multi:
                 result_arrays.append(np.stack([ep_preds[c].values for c in columns]))
             else:
@@ -439,20 +497,9 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
                         f"config.quantile_levels, or request a subset of the available levels."
                     )
 
-            from autogluon.timeseries import TimeSeriesDataFrame
-
-            context = data.copy()
-            context["item_id"] = context[episode_col].astype(str)
-            if config.time_col in context.columns:
-                context["timestamp"] = pd.to_datetime(context[config.time_col])
-            else:
-                context["timestamp"] = context.index
-            context = context.rename(columns={config.target_col: "target"})
-
-            ag_cols = ["item_id", "timestamp", "target"] + config.covariate_cols
-            ag_cols = [c for c in ag_cols if c in context.columns]
-            context = context[ag_cols].set_index(["item_id", "timestamp"])
-            ts_data = TimeSeriesDataFrame(context)
+            # Reuse _prepare_autogluon_data (handles both single- and multi-target)
+            batch_data = data.rename(columns={episode_col: "episode_id"})
+            ts_data = self._prepare_autogluon_data(batch_data)
 
             ag_predictions = self.predictor.predict(ts_data)
 
@@ -464,15 +511,14 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
             multi = len(columns) > 1
 
             results: Dict[str, np.ndarray] = {}
-            for item_id in episode_ids:
-                if item_id in ag_predictions.index.get_level_values(0):
-                    ep_preds = ag_predictions.loc[item_id]
+            for ep_id in episode_ids:
+                ag_id = self._ag_item_id(ep_id)
+                if ag_id in ag_predictions.index.get_level_values(0):
+                    ep_preds = ag_predictions.loc[ag_id]
                     if multi:
-                        results[item_id] = np.stack(
-                            [ep_preds[c].values for c in columns]
-                        )
+                        results[ep_id] = np.stack([ep_preds[c].values for c in columns])
                     else:
-                        results[item_id] = ep_preds[columns[0]].values
+                        results[ep_id] = ep_preds[columns[0]].values
             return results
 
         # Zero-shot path: batch via Chronos2Pipeline

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -137,9 +137,9 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
 
         # Multi-target mode: stack each target col as a separate item
         if config.is_multitarget:
-            info_print(f"Multi-target mode: {config.target_cols}")
+            info_print(f"Multi-target mode: {config.joint_target_cols}")
             ts_train = format_segments_for_autogluon(
-                segments, target_cols=config.target_cols
+                segments, target_cols=config.joint_target_cols
             )
         else:
             ts_train = format_segments_for_autogluon(
@@ -278,7 +278,7 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
             data_list = []
             for ep_id in context["episode_id"].unique():
                 ep_data = context[context["episode_id"] == ep_id]
-                for col in config.target_cols:
+                for col in config.joint_target_cols:
                     if col not in ep_data.columns:
                         logger.warning(
                             "Target column '%s' missing for episode %s", col, ep_id
@@ -298,7 +298,7 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
             if not data_list:
                 raise ValueError(
                     f"No valid multi-target data found. Check that target_cols "
-                    f"{config.target_cols} exist in the input DataFrame."
+                    f"{config.joint_target_cols} exist in the input DataFrame."
                 )
             combined = pd.concat(data_list, ignore_index=True)
             combined = combined.set_index(["item_id", "timestamp"])

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -299,7 +299,7 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
                     data_list.append(df)
             if not data_list:
                 raise ValueError(
-                    f"No valid multi-target data found. Check that target_cols "
+                    f"No valid multi-target data found. Check that joint_target_cols "
                     f"{config.joint_target_cols} exist in the input DataFrame."
                 )
             combined = pd.concat(data_list, ignore_index=True)
@@ -330,8 +330,8 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
         item_id equals the episode_id directly.
         """
         if self.config.is_multitarget:
-            return f"{episode_id}__{self.config.target_col}"
-        return episode_id
+            return f"{str(episode_id)}__{self.config.target_col}"
+        return str(episode_id)
 
     def _zero_shot_forecast(self, data: pd.DataFrame, quantile_levels=None):
         """Run zero-shot inference via Chronos2Pipeline.

--- a/src/models/chronos2/utils.py
+++ b/src/models/chronos2/utils.py
@@ -67,12 +67,14 @@ def format_segments_for_autogluon(
     segments: Dict[str, pd.DataFrame],
     target_col: str = "bg_mM",
     covariate_cols: Optional[List[str]] = None,
+    target_cols: Optional[List[str]] = None,
 ) -> Any:
     """Convert gap-handled segments to AutoGluon TimeSeriesDataFrame.
 
-    Each segment becomes one item_id with variable length. AutoGluon
-    creates sliding windows internally during training, seeing both
-    past and future covariate values within each segment.
+    Single-target mode (default): each segment becomes one item_id.
+    Multi-target mode (target_cols has >1 entry): each segment is stacked
+    into N items (one per target column), with item_id = "{seg_id}__{col}".
+    covariate_cols are ignored in multi-target mode.
 
     Args:
         segments: Dict mapping segment_id -> DataFrame with DatetimeIndex.
@@ -80,12 +82,18 @@ def format_segments_for_autogluon(
         target_col: Column name for the target variable (e.g., "bg_mM").
         covariate_cols: Column names for covariates (e.g., ["iob"] or
             ["iob", "cob"]). Missing columns are filled with 0.
+        target_cols: Column names for multi-target mode (e.g., ["bg_mM", "iob"]).
+            When provided with >1 entry, enables long-format stacking.
 
     Returns:
         TimeSeriesDataFrame with columns ["target", <covariates>],
         indexed by (item_id, timestamp).
     """
     from autogluon.timeseries import TimeSeriesDataFrame
+
+    # Multi-target mode: stack each target column as a separate item
+    if target_cols and len(target_cols) > 1:
+        return _format_segments_multitarget(segments, target_cols)
 
     if covariate_cols is None:
         covariate_cols = ["iob"]
@@ -119,6 +127,65 @@ def format_segments_for_autogluon(
 
     logger.debug(
         "Formatted %d segments for AutoGluon: %s", len(segments), combined.shape
+    )
+    return TimeSeriesDataFrame(combined)
+
+
+def _format_segments_multitarget(
+    segments: Dict[str, pd.DataFrame],
+    target_cols: List[str],
+) -> Any:
+    """Stack multiple target columns as separate items for joint training.
+
+    Each segment contributes len(target_cols) items to the panel. For example,
+    with target_cols=["bg_mM", "iob"], segment "seg_001" produces items
+    "seg_001__bg_mM" and "seg_001__iob". The model trains on all items jointly
+    via shared weights.
+
+    Args:
+        segments: Dict mapping segment_id -> DataFrame with DatetimeIndex.
+        target_cols: Column names to use as targets (e.g., ["bg_mM", "iob"]).
+
+    Returns:
+        TimeSeriesDataFrame with single "target" column, indexed by
+        (item_id, timestamp).
+    """
+    from autogluon.timeseries import TimeSeriesDataFrame
+
+    data_list = []
+
+    for seg_id, seg_df in segments.items():
+        for col in target_cols:
+            if col not in seg_df.columns:
+                logger.warning(
+                    "Target column '%s' not in segment %s, skipping", col, seg_id
+                )
+                continue
+            vals = seg_df[col].ffill().fillna(0)
+            df = pd.DataFrame(
+                {
+                    "item_id": f"{seg_id}__{col}",
+                    "timestamp": seg_df.index,
+                    "target": vals.values,
+                }
+            )
+            data_list.append(df)
+
+    if not data_list:
+        raise ValueError(
+            "No valid multi-target segments found. "
+            "Check that target_cols columns exist in the data."
+        )
+
+    combined = pd.concat(data_list, ignore_index=True)
+    combined = combined.set_index(["item_id", "timestamp"])
+
+    logger.debug(
+        "Formatted %d multi-target items (%d segments x %d targets): %s",
+        len(data_list),
+        len(segments),
+        len(target_cols),
+        combined.shape,
     )
     return TimeSeriesDataFrame(combined)
 

--- a/tests/models/test_chronos2.py
+++ b/tests/models/test_chronos2.py
@@ -239,6 +239,71 @@ class TestChronos2:
 
 
 # ---------------------------------------------------------------------------
+# Multi-target (joint co-target forecasting)
+# ---------------------------------------------------------------------------
+
+
+class TestMultitarget:
+    """Joint co-target mode: target_cols=["bg_mM", "iob"] stacks each column
+    as a separate AutoGluon item, so Chronos-2 trains on both jointly."""
+
+    def test_is_multitarget_requires_two_or_more_targets(self):
+        assert not Chronos2Config().is_multitarget  # default: empty list
+        assert Chronos2Config(target_cols=["bg_mM", "iob"]).is_multitarget
+        # Single-entry target_cols is rejected (ambiguous — use target_col instead)
+        with pytest.raises(ValueError, match="target_cols has 1 entry"):
+            Chronos2Config(target_cols=["bg_mM"])
+
+    def test_segments_stacked_as_separate_items(self):
+        """2 segments x 2 targets → 4 items named seg_0__bg_mM, seg_0__iob, etc."""
+        rng = np.random.default_rng(42)
+        segments = {}
+        for i in range(2):
+            idx = pd.date_range("2024-01-01", periods=20, freq="5min")
+            segments[f"seg_{i}"] = pd.DataFrame(
+                {"bg_mM": rng.normal(7, 1, 20), "iob": rng.exponential(0.5, 20)},
+                index=idx + pd.Timedelta(days=i),
+            )
+
+        ts = format_segments_for_autogluon(segments, target_cols=["bg_mM", "iob"])
+
+        assert ts.num_items == 4
+        assert list(ts.columns) == ["target"]
+        assert sorted(ts.index.get_level_values(0).unique()) == [
+            "seg_0__bg_mM",
+            "seg_0__iob",
+            "seg_1__bg_mM",
+            "seg_1__iob",
+        ]
+        # Values match originals
+        np.testing.assert_array_almost_equal(
+            ts.loc["seg_0__bg_mM"]["target"].values, segments["seg_0"]["bg_mM"].values
+        )
+
+    def test_inference_extracts_primary_target_only(self):
+        """_prepare_autogluon_data stacks both targets, but _ag_item_id
+        maps episode IDs to the primary target (bg_mM) for extraction."""
+        config = Chronos2Config(target_cols=["bg_mM", "iob"])
+        model = Chronos2Forecaster(config)
+
+        data = pd.DataFrame(
+            {
+                "datetime": pd.date_range("2024-01-01", periods=30, freq="5min"),
+                "bg_mM": np.ones(30) * 7.0,
+                "iob": np.ones(30) * 0.5,
+                "episode_id": "ep_0",
+            }
+        )
+        ts = model._prepare_autogluon_data(data)
+
+        # Both targets present as items
+        assert "ep_0__bg_mM" in ts.index.get_level_values(0)
+        assert "ep_0__iob" in ts.index.get_level_values(0)
+        # Extraction targets primary only
+        assert model._ag_item_id("ep_0") == "ep_0__bg_mM"
+
+
+# ---------------------------------------------------------------------------
 # GPU-only end-to-end tests
 # ---------------------------------------------------------------------------
 

--- a/tests/models/test_chronos2.py
+++ b/tests/models/test_chronos2.py
@@ -244,15 +244,15 @@ class TestChronos2:
 
 
 class TestMultitarget:
-    """Joint co-target mode: target_cols=["bg_mM", "iob"] stacks each column
+    """Joint co-target mode: joint_target_cols=["bg_mM", "iob"] stacks each column
     as a separate AutoGluon item, so Chronos-2 trains on both jointly."""
 
     def test_is_multitarget_requires_two_or_more_targets(self):
         assert not Chronos2Config().is_multitarget  # default: empty list
-        assert Chronos2Config(target_cols=["bg_mM", "iob"]).is_multitarget
-        # Single-entry target_cols is rejected (ambiguous — use target_col instead)
-        with pytest.raises(ValueError, match="target_cols has 1 entry"):
-            Chronos2Config(target_cols=["bg_mM"])
+        assert Chronos2Config(joint_target_cols=["bg_mM", "iob"]).is_multitarget
+        # Single-entry joint_target_cols is rejected (ambiguous — use target_col instead)
+        with pytest.raises(ValueError, match="joint_target_cols has 1 entry"):
+            Chronos2Config(joint_target_cols=["bg_mM"])
 
     def test_segments_stacked_as_separate_items(self):
         """2 segments x 2 targets → 4 items named seg_0__bg_mM, seg_0__iob, etc."""
@@ -283,7 +283,7 @@ class TestMultitarget:
     def test_inference_extracts_primary_target_only(self):
         """_prepare_autogluon_data stacks both targets, but _ag_item_id
         maps episode IDs to the primary target (bg_mM) for extraction."""
-        config = Chronos2Config(target_cols=["bg_mM", "iob"])
+        config = Chronos2Config(joint_target_cols=["bg_mM", "iob"])
         model = Chronos2Forecaster(config)
 
         data = pd.DataFrame(


### PR DESCRIPTION
### Summary
- Adds `joint_target_cols` config option to Chronos-2 that enables joint multi-target training (e.g. `joint_target_cols: ["bg_mM", "iob"]`), where each target column becomes a separate item in the AutoGluon panel with shared Chronos-2 weights
- At inference, only the primary target (`target_col`) predictions are extracted
- Covariate mode (default) is unchanged — `joint_target_cols` is empty by default
- Includes config YAML for joint BG+IOB experiments (`02_joint_bg_iob.yaml`)

Closes #366 

### Changes
- **config.py**: `joint_target_cols` field + `is_multitarget` property with validation
- **utils.py**: `_format_segments_multitarget()` for long-format stacking of target columns
- **model.py**: `_prepare_autogluon_data()`, `_autogluon_extract()`, `_predict_batch()` dispatch on `is_multitarget`; refactored `_predict_batch()` to reuse `_prepare_autogluon_data()`
- **nocturnal.py**: Minor fix for covariate column handling in eval
- **test_chronos2.py**: 3 unit tests covering config, stacking, and inference extraction

### Testing
- [X] Unit tests pass (`.venvs/chronos2/bin/python -m pytest tests/models/test_chronos2.py::TestMultitarget`)
- [X] 15k-step training runs complete for both covariate and joint modes
- [X] Nocturnal eval produces valid RMSE for both checkpoints
