### PR TITLE
Update to Toto PR.

### DIFF
--- a/configs/models/toto/00_bg_only.yaml
+++ b/configs/models/toto/00_bg_only.yaml
@@ -17,7 +17,7 @@
 # =============================================================================
 
 context_length: 512
-forecast_length: 96  # 6 hours at 5-min intervals
+forecast_length: 96  # 8 hours at 5-min intervals
 
 training_mode: "fine_tune"
 freeze_backbone: false
@@ -36,7 +36,3 @@ val_batch_size: 1
 
 # BG only — no covariates
 covariate_cols: []
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/00_bg_only.yaml
+++ b/configs/models/toto/00_bg_only.yaml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Toto — Blood Glucose Only Baseline
+# =============================================================================
+# Fine-tunes Toto on BG (bg_mM) as the sole input — no covariates.
+# This is the BG-only baseline for comparison against covariate models.
+#
+# Toto trains by gradient steps (max_steps) via PyTorch Lightning.
+# Default 3000 steps is a production run. Use max_steps=100 for smoke tests.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/00_bg_only.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96  # 6 hours at 5-min intervals
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+# Step-based training (PyTorch Lightning).
+max_steps: 10000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+# Batch sizes
+train_batch_size: 4
+val_batch_size: 1
+
+# BG only — no covariates
+covariate_cols: []
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/01_bg_iob.yaml
+++ b/configs/models/toto/01_bg_iob.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB Only  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Isolates insulin-on-board (IOB) as the sole covariate.
+# Compare against 00 (BG-only) to measure IOB contribution.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/01_bg_iob.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 15000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/01_bg_iob.yaml
+++ b/configs/models/toto/01_bg_iob.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/02_bg_iob_ia.yaml
+++ b/configs/models/toto/02_bg_iob_ia.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, insulin_availability]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/02_bg_iob_ia.yaml
+++ b/configs/models/toto/02_bg_iob_ia.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Adds insulin_availability alongside IOB.
+# Compare against 01 (IOB only) to check if availability signal helps.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/02_bg_iob_ia.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/03_bg_iob_ia_high_lr.yaml
+++ b/configs/models/toto/03_bg_iob_ia_high_lr.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, insulin_availability]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/03_bg_iob_ia_high_lr.yaml
+++ b/configs/models/toto/03_bg_iob_ia_high_lr.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=5e-4  |  ctx=512
+# =============================================================================
+# Same covariates as 02, but 5× higher learning rate.
+# Compare against 02 to check LR sensitivity.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/03_bg_iob_ia_high_lr.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 5.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/04_bg_iob_short_ctx.yaml
+++ b/configs/models/toto/04_bg_iob_short_ctx.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, insulin_availability]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/04_bg_iob_short_ctx.yaml
+++ b/configs/models/toto/04_bg_iob_short_ctx.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + insulin_availability  |  lr=1e-4  |  ctx=288
+# =============================================================================
+# Same covariates as 02, but shorter context window (288 vs 512).
+# Compare against 02 to check context length sensitivity.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/04_bg_iob_short_ctx.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 brown_2019 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 288
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, insulin_availability]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/05_bg_iob_cob.yaml
+++ b/configs/models/toto/05_bg_iob_cob.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Adds carbs-on-board (COB) alongside IOB.
+# Baseline carb addition — compare against 01 (IOB only).
+# brown_2019 excluded (no meal data in DCLP3 export).
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/05_bg_iob_cob.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/05_bg_iob_cob.yaml
+++ b/configs/models/toto/05_bg_iob_cob.yaml
@@ -31,7 +31,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, cob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/06_bg_full_features.yaml
+++ b/configs/models/toto/06_bg_full_features.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + COB + insulin_avail + carb_avail  |  lr=1e-4  |  ctx=512
+# =============================================================================
+# Kitchen-sink: all four covariates.
+# Compare against 05 (IOB + COB only) to measure availability signal value.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/06_bg_full_features.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob, insulin_availability, carb_availability]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/06_bg_full_features.yaml
+++ b/configs/models/toto/06_bg_full_features.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, cob, insulin_availability, carb_availability]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/07_bg_iob_cob_high_lr.yaml
+++ b/configs/models/toto/07_bg_iob_cob_high_lr.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=5e-4  |  ctx=512
+# =============================================================================
+# Same covariates as 05, but 5× higher learning rate.
+# Compare against 05 to check LR sensitivity with carb covariates.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/07_bg_iob_cob_high_lr.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 5.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/07_bg_iob_cob_high_lr.yaml
+++ b/configs/models/toto/07_bg_iob_cob_high_lr.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, cob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
+++ b/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — BG + IOB + COB  |  lr=1e-4  |  ctx=288
+# =============================================================================
+# Same covariates as 05, but shorter context window (288 vs 512).
+# Compare against 05 to check context length sensitivity with carbs.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/08_bg_iob_cob_short_ctx.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017 lynch_2022" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 288
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 3000
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 200
+stable_steps: 1000
+decay_steps: 1000
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
+++ b/configs/models/toto/08_bg_iob_cob_short_ctx.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, cob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/bg_iob_cob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_cob_smoke_test.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG + IOB + COB, 100 steps)
+# =============================================================================
+# Fast end-to-end validation of the carbs covariate path.
+# Exercises the COB + IOB exogenous-variable pipeline.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_iob_cob_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob, cob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/bg_iob_cob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_cob_smoke_test.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob, cob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/bg_iob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_smoke_test.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG + IOB, 100 steps)
+# =============================================================================
+# Fast end-to-end validation of the covariate path.
+# Exercises the IOB exogenous-variable pipeline.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_iob_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+covariate_cols: [iob]
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/bg_iob_smoke_test.yaml
+++ b/configs/models/toto/bg_iob_smoke_test.yaml
@@ -30,7 +30,3 @@ train_batch_size: 4
 val_batch_size: 1
 
 covariate_cols: [iob]
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/configs/models/toto/bg_only_smoke_test.yaml
+++ b/configs/models/toto/bg_only_smoke_test.yaml
@@ -1,0 +1,39 @@
+# =============================================================================
+# Toto — Smoke Test Configuration (BG only, 100 steps)
+# =============================================================================
+# Fast end-to-end validation. max_steps=100 keeps it under a few minutes.
+# Use this to verify the Toto fine-tuning pipeline works before launching
+# real sweeps.
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" \
+#   MODEL_CONFIG="configs/models/toto/bg_only_smoke_test.yaml" \
+#   CONFIG_DIR="configs/data/holdout_10pct" \
+#   DATASETS="aleppo_2017" \
+#   SKIP_TRAINING="false" SKIP_STEPS="7" \
+#     ./scripts/examples/run_holdout_generic_workflow.sh
+# =============================================================================
+
+context_length: 512
+forecast_length: 96
+
+training_mode: "fine_tune"
+freeze_backbone: false
+
+# 100 steps = fast smoke test. Use 3000 for production.
+max_steps: 100
+lr: 1.0e-4
+min_lr: 1.0e-5
+warmup_steps: 20
+stable_steps: 40
+decay_steps: 40
+
+train_batch_size: 4
+val_batch_size: 1
+
+# BG only — no covariates
+covariate_cols: []
+target_col: "bg_mM"
+patient_col: "p_num"
+time_col: "datetime"
+interval_mins: 5

--- a/configs/models/toto/bg_only_smoke_test.yaml
+++ b/configs/models/toto/bg_only_smoke_test.yaml
@@ -33,7 +33,3 @@ val_batch_size: 1
 
 # BG only — no covariates
 covariate_cols: []
-target_col: "bg_mM"
-patient_col: "p_num"
-time_col: "datetime"
-interval_mins: 5

--- a/notes/toto_hyperparameter.md
+++ b/notes/toto_hyperparameter.md
@@ -1,0 +1,321 @@
+# Toto Hyperparameter Sweep — Training Commands
+
+All commands assume you are in the repo root.
+`CONFIG_DIR` is set to `holdout_10pct` throughout; change if needed.
+Step 7 (resume training) is skipped via `SKIP_STEPS="7"` on every run.
+
+---
+
+## Environment Setup (run once per session)
+
+**1. Activate conda base environment:**
+```bash
+conda activate env-in-conda
+```
+
+**2. Create or activate the Toto model venv** (first run creates `.venvs/toto` and installs deps; subsequent runs just activate it):
+```bash
+source scripts/setup_model_env.sh toto
+```
+
+> The training workflow script (`run_holdout_generic_workflow.sh`) will auto-activate `.venvs/toto` once it exists. The `source scripts/setup_model_env.sh toto` step above is only needed to create it the first time, or if you want to run Python directly outside the workflow script.
+
+---
+
+## Smoke Tests (run these first)
+
+These use 100-step configs for fast end-to-end validation (<5 min each).
+
+**BG-only path** — verifies the basic Toto fine-tuning pipeline:
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_only_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+**CGM+Insulin path** — exercises `bg_iob_smoke_test.yaml` end-to-end:
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_iob_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+**CGM+Insulin+Carbs path** — exercises `bg_iob_cob_smoke_test.yaml` end-to-end (carb feature engineering path):
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/bg_iob_cob_smoke_test.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## BG-Only Baseline
+
+Datasets: `aleppo_2017 brown_2019 lynch_2022 tamborlane_2008`
+
+### 00 — BG only  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/00_bg_only.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## CGM + Insulin Runs
+
+Datasets: `aleppo_2017 brown_2019 lynch_2022`
+
+### 01 — IOB only  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/01_bg_iob.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 02 — IOB + insulin_availability  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/02_bg_iob_ia.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 03 — IOB + insulin_availability  |  lr=5e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/03_bg_iob_ia_high_lr.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 04 — IOB + insulin_availability  |  lr=1e-4  |  ctx=288
+```bash
+CUDA_VISIBLE_DEVICES=1 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/04_bg_iob_short_ctx.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 brown_2019 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## CGM + Insulin + Carbs Runs
+
+Datasets: `aleppo_2017 lynch_2022`
+(brown_2019 excluded — no meal data in DCLP3 export)
+
+### 05 — IOB + COB  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/05_bg_iob_cob.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 06 — IOB + COB + insulin_availability + carb_availability  |  lr=1e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/06_bg_full_features.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 07 — IOB + COB  |  lr=5e-4  |  ctx=512
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/07_bg_iob_cob_high_lr.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+### 08 — IOB + COB  |  lr=1e-4  |  ctx=288
+```bash
+CUDA_VISIBLE_DEVICES=0 MODEL_TYPE="toto" MODEL_CONFIG="configs/models/toto/08_bg_iob_cob_short_ctx.yaml" CONFIG_DIR="configs/data/holdout_10pct" DATASETS="aleppo_2017 lynch_2022" SKIP_TRAINING="false" SKIP_STEPS="7" ./scripts/examples/run_holdout_generic_workflow.sh
+```
+
+---
+
+## Comparison Matrix
+
+| Config | Covariates                          | LR   | Context | Datasets           | Key comparison                |
+| ------ | ----------------------------------- | ---- | ------- | ------------------ | ----------------------------- |
+| 00     | none                                | 1e-4 | 512     | ale, bro, lyn, tam | BG-only baseline              |
+| **01** | iob                                 | 1e-4 | 512     | ale, bro, lyn      | isolates IOB vs 00            |
+| **02** | iob, insulin_avail                  | 1e-4 | 512     | ale, bro, lyn      | +availability vs 01           |
+| **03** | iob, insulin_avail                  | 5e-4 | 512     | ale, bro, lyn      | higher LR vs 02               |
+| **04** | iob, insulin_avail                  | 1e-4 | 288     | ale, bro, lyn      | shorter ctx vs 02             |
+| **05** | iob, cob                            | 1e-4 | 512     | ale, lyn           | baseline carb addition vs 01  |
+| **06** | iob, cob, insulin_avail, carb_avail | 1e-4 | 512     | ale, lyn           | kitchen-sink vs 05            |
+| **07** | iob, cob                            | 5e-4 | 512     | ale, lyn           | higher LR vs 05               |
+| **08** | iob, cob                            | 1e-4 | 288     | ale, lyn           | shorter ctx vs 05             |
+
+---
+
+## Nocturnal Evaluation
+
+After training completes, run nocturnal evaluation (midnight-anchored 8-hour overnight forecasting) on each holdout dataset. Replace `<CHECKPOINT>` with the actual `model.pt` path from the training output.
+
+> **Tip**: Each training run prints the checkpoint path at the end. It lives at
+> `trained_models/artifacts/toto/<timestamp>_RID<run_id>_holdout_workflow/model.pt`
+
+### 00 — BG only (zero-shot baseline: omit `--checkpoint`)
+
+Checkpoint: `trained_models/artifacts/toto/2026-03-18_06:21_RID20260318_062105_1962383_holdout_workflow/model.pt`
+
+```bash
+# Zero-shot (no checkpoint)
+for ds in aleppo_2017 brown_2019 lynch_2022 tamborlane_2008; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/00_bg_only.yaml \
+    --context-length 512 --forecast-length 96 \
+    --cuda-device 0
+done
+
+# Fine-tuned
+for ds in aleppo_2017 brown_2019 lynch_2022 tamborlane_2008; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/00_bg_only.yaml \
+    --context-length 512 --forecast-length 96 \
+    --cuda-device 0 \
+    --checkpoint trained_models/artifacts/toto/2026-03-18_06:21_RID20260318_062105_1962383_holdout_workflow/model.pt
+done
+```
+
+### 01 — IOB only
+
+Checkpoint: `trained_models/artifacts/toto/2026-03-18_20:06_RID20260318_200624_2050916_holdout_workflow/model.pt`
+
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/01_bg_iob.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob \
+    --cuda-device 0 \
+    --checkpoint trained_models/artifacts/toto/2026-03-18_20:06_RID20260318_200624_2050916_holdout_workflow/model.pt
+done
+```
+
+### 02 — IOB + insulin_availability
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/02_bg_iob_ia.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 03 — IOB + insulin_availability  |  lr=5e-4
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/03_bg_iob_ia_high_lr.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 04 — IOB + insulin_availability  |  ctx=288
+```bash
+for ds in aleppo_2017 brown_2019 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/04_bg_iob_short_ctx.yaml \
+    --context-length 288 --forecast-length 96 \
+    --covariate-cols iob insulin_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 05 — IOB + COB
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/05_bg_iob_cob.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 06 — IOB + COB + insulin_availability + carb_availability
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/06_bg_full_features.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob insulin_availability carb_availability \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 07 — IOB + COB  |  lr=5e-4
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/07_bg_iob_cob_high_lr.yaml \
+    --context-length 512 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+### 08 — IOB + COB  |  ctx=288
+```bash
+for ds in aleppo_2017 lynch_2022; do
+  python scripts/experiments/nocturnal_hypo_eval.py \
+    --model toto \
+    --dataset "$ds" \
+    --config-dir configs/data/holdout_10pct \
+    --model-config configs/models/toto/08_bg_iob_cob_short_ctx.yaml \
+    --context-length 288 --forecast-length 96 \
+    --covariate-cols iob cob \
+    --cuda-device 0 \
+    --checkpoint <CHECKPOINT>
+done
+```
+
+---
+
+## Notes
+
+- **Model**: `Datadog/Toto-Open-Base-1.0` — downloaded automatically on first run.
+- **Training**: Toto uses PyTorch Lightning with `max_steps` (gradient steps, not epochs). Default 3000 steps. Smoke tests use 100 steps.
+- **LR schedule**: Warmup (200 steps) → stable peak (1000 steps) → cosine decay (1000 steps) down to `min_lr`.
+- **Covariates**: Passed as exogenous variables (past-only) via `covariate_cols` in the YAML config. Toto encodes these alongside BG as multivariate input.
+- **Step 7 skipped**: Resume training is skipped (`SKIP_STEPS="7"`) on all runs since we want clean single-phase training results.
+- **Forecast length**: 96 steps (8 hours at 5-min intervals) to match Chronos-2 sweep.
+- **Results**: Written to `trained_models/artifacts/toto/<timestamp>_RID<run_id>_holdout_workflow/`.
+
+## Environment Setup
+
+The `.venvs/toto` venv required the following fixes for Blackwell GPUs:
+
+```bash
+# PyTorch 2.10 for sm_120 (Blackwell) support
+pip install --index-url https://download.pytorch.org/whl/cu128 torch==2.10.0+cu128
+
+# setuptools <82 (82+ removed pkg_resources which toto-ts imports)
+pip install "setuptools<82"
+```
+
+Additionally, the installed toto package's `helpers.py` was patched to skip `pd.infer_freq()` when
+`freq` is already present in the HuggingFace dataset (our CGM data has gaps that cause
+`pd.infer_freq` to return `None`). The patch is at:
+
+```
+.venvs/toto/lib/python3.12/site-packages/toto/data/util/helpers.py  (line ~213)
+```
+
+Changed unconditional `hf_dataset.map(lambda: {"freq": pd.infer_freq(...)})` to:
+```python
+if "freq" not in hf_dataset.column_names:
+    hf_dataset = hf_dataset.map(lambda item: {"freq": pd.infer_freq(...)})
+```

--- a/scripts/examples/example_holdout_generic_workflow.py
+++ b/scripts/examples/example_holdout_generic_workflow.py
@@ -422,15 +422,21 @@ class ModelFactory:
         try:
             from src.models.toto import TotoForecaster, TotoConfig
 
-            toto_config = TotoConfig(
-                context_length=config.context_length,
-                forecast_length=config.forecast_length,
-                batch_size=config.batch_size,
-                num_epochs=config.num_epochs,
-                lr=config.learning_rate,
-                use_cpu=config.use_cpu,
-                **config.extra_config,
-            )
+            # Build kwargs from extra_config, letting YAML values take
+            # precedence for Toto-specific params (lr, max_steps, etc.)
+            toto_kwargs = dict(config.extra_config) if config.extra_config else {}
+
+            # Set explicit args only if not already provided by YAML
+            toto_kwargs.setdefault("context_length", config.context_length)
+            toto_kwargs.setdefault("forecast_length", config.forecast_length)
+            toto_kwargs.setdefault("batch_size", config.batch_size)
+            if config.num_epochs is not None:
+                toto_kwargs.setdefault("num_epochs", config.num_epochs)
+            if config.learning_rate is not None and "lr" not in toto_kwargs:
+                toto_kwargs["lr"] = config.learning_rate
+            toto_kwargs.setdefault("use_cpu", config.use_cpu)
+
+            toto_config = TotoConfig(**toto_kwargs)
 
             return TotoForecaster(toto_config, distributed_config=distributed_config)
         except ImportError as e:

--- a/scripts/examples/run_holdout_generic_workflow.sh
+++ b/scripts/examples/run_holdout_generic_workflow.sh
@@ -58,6 +58,7 @@ RUN_ID="${RUN_ID:-$(date +%Y%m%d_%H%M%S)_$$}"
 : ${CONFIG_DIR:="configs/data/holdout_10pct"}
 : ${OUTPUT_BASE_DIR:="trained_models/artifacts/${MODEL_TYPE}/$(date +%Y-%m-%d_%H:%M)_RID${RUN_ID}_holdout_workflow"}
 : ${SKIP_TRAINING:="true"}
+: ${SKIP_STEPS:=""}      # Space-separated step numbers to skip (e.g., SKIP_STEPS="7" or SKIP_STEPS="4 7")
 : ${EPOCHS:=""}          # Leave empty to use YAML config value; set to override (e.g., EPOCHS=10)
 : ${BATCH_SIZE:=""}      # Leave empty to use YAML config value; set to override (e.g., BATCH_SIZE=4096)
 : ${MODEL_TYPE:="ttm"}  # Model type: ttm, chronos, moment, etc.
@@ -80,6 +81,7 @@ echo "  Datasets: $DATASETS"
 echo "  Config dir: $CONFIG_DIR"
 echo "  Output base dir: $OUTPUT_BASE_DIR"
 echo "  Skip training: $SKIP_TRAINING"
+echo "  Skip steps: ${SKIP_STEPS:-none}"
 echo "  Epochs: ${EPOCHS:-from YAML or default}"
 echo "  Batch size: ${BATCH_SIZE:-from YAML or default}"
 echo "  Model config: ${MODEL_CONFIG:-None (using defaults)}"
@@ -199,6 +201,9 @@ fi
 if [ "$SKIP_TRAINING" = "true" ]; then
     CMD="$CMD --skip-training"
 fi
+if [ -n "$SKIP_STEPS" ]; then
+    CMD="$CMD --skip-steps $SKIP_STEPS"
+fi
 
 echo "Running combined workflow..."
 # Pretty print for logs (display only)
@@ -218,10 +223,12 @@ if [ -n "$MODEL_CONFIG" ]; then
     echo "    --model-config $MODEL_CONFIG \\"
 fi
 if [ "$SKIP_TRAINING" = "true" ]; then
-    echo "    --skip-training"
-else
-    echo ""
+    echo "    --skip-training \\"
 fi
+if [ -n "$SKIP_STEPS" ]; then
+    echo "    --skip-steps $SKIP_STEPS \\"
+fi
+echo ""
 echo ""
 
 # Create log filename with run ID (matches SLURM pattern with job ID)

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -37,11 +37,6 @@ class TotoConfig(ModelConfig):
             "val_batch_size",
             "val_prediction_len",
             "covariate_cols",
-            # YAML metadata fields used by the workflow but not by ModelConfig
-            "target_col",
-            "patient_col",
-            "time_col",
-            "interval_mins",
         }
 
         # Filter out Toto-specific params from kwargs for parent class

--- a/src/models/toto/config.py
+++ b/src/models/toto/config.py
@@ -37,6 +37,11 @@ class TotoConfig(ModelConfig):
             "val_batch_size",
             "val_prediction_len",
             "covariate_cols",
+            # YAML metadata fields used by the workflow but not by ModelConfig
+            "target_col",
+            "patient_col",
+            "time_col",
+            "interval_mins",
         }
 
         # Filter out Toto-specific params from kwargs for parent class

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -157,6 +157,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         self,
         data: pd.DataFrame,
         episode_col: str,
+        quantile_levels: Optional[List[float]] = None,
     ) -> Dict[str, np.ndarray]:
         """Batched prediction: stack episodes into one forward pass.
 
@@ -164,6 +165,12 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         recent timesteps are right-aligned. The padding_mask tells the model
         which timesteps are real data.
         """
+        if quantile_levels is not None:
+            logger.warning(
+                "TotoForecaster does not support quantile forecasting yet; "
+                "quantile_levels will be ignored and point forecasts returned."
+            )
+
         covariate_cols = self.config.covariate_cols or []
         num_covariates = len(covariate_cols)
         num_variates = 1 + num_covariates
@@ -262,6 +269,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             record = {
                 "timestamp": ts_strings,
                 "target": target.tolist(),
+                "freq": f"{INTERVAL_MINS}min",
             }
 
             # Add covariates as separate fields (each becomes an ev_field)

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -165,12 +165,6 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         recent timesteps are right-aligned. The padding_mask tells the model
         which timesteps are real data.
         """
-        if quantile_levels is not None:
-            logger.warning(
-                "TotoForecaster does not support quantile forecasting yet; "
-                "quantile_levels will be ignored and point forecasts returned."
-            )
-
         covariate_cols = self.config.covariate_cols or []
         num_covariates = len(covariate_cols)
         num_variates = 1 + num_covariates


### PR DESCRIPTION
Some minor changes to make toto work with the new GPUs, also note thatt we needed to make changes to the site-packages that are not in the PR but if you go to: .venvs/toto/lib/python3.12/site-packages/toto/data/util/helpers.py, this:     if 'freq' not in hf_dataset.column_names: was added above the line  hf_dataset = hf_dataset.map(lambda item: {'freq': pd.infer_freq(pd.to_datetime(item['timestamp']))}) around line 210...., Also I added a bunch of configuration files for fine tuning toto.