### PR TITLE
fix(tests): repair sundial target selection and batch override compat…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-ttm:
 	$(VENVS_DIR)/ttm/bin/python -m pytest tests/models/ -v -k ttm
 
 test-sundial:
-	$(VENVS_DIR)/sundial/bin/python -m pytest tests/models/ -v -k sundial
+	$(VENVS_DIR)/sundial/bin/python -m pytest tests/models/ -v -k "not ttm and not timesfm and not chronos2"
 
 test-timesfm:
 	$(VENVS_DIR)/timesfm/bin/python -m pytest tests/models/ -v -k timesfm

--- a/src/models/base/base_model.py
+++ b/src/models/base/base_model.py
@@ -497,7 +497,12 @@ class BaseTimeSeriesFoundationModel(ABC):
         if not input_ids:
             return {}
 
-        results = self._predict_batch(data, episode_col, quantile_levels)
+        if quantile_levels is None:
+            # Backward-compatible dispatch for model overrides that implement
+            # _predict_batch(self, data, episode_col) without quantile_levels.
+            results = self._predict_batch(data, episode_col)
+        else:
+            results = self._predict_batch(data, episode_col, quantile_levels)
 
         missing = input_ids - set(results.keys())
         if missing:

--- a/tests/models/test_timesfm_config.py
+++ b/tests/models/test_timesfm_config.py
@@ -1,0 +1,18 @@
+"""Tests for TimesFM configuration validation."""
+
+import pytest
+
+pytest.importorskip("torch")
+
+from src.models.timesfm.config import TimesFMConfig
+
+
+class TestTimesFMConfigValidation:
+    def test_interval_mins_default_is_valid(self):
+        cfg = TimesFMConfig()
+        assert cfg.interval_mins == 5
+
+    @pytest.mark.parametrize("interval_mins", [0, -5])
+    def test_interval_mins_must_be_positive(self, interval_mins):
+        with pytest.raises(ValueError, match="interval_mins must be positive"):
+            TimesFMConfig(interval_mins=interval_mins)

--- a/tests/models/test_timesfm_config.py
+++ b/tests/models/test_timesfm_config.py
@@ -1,18 +1,28 @@
 """Tests for TimesFM configuration validation."""
 
+import importlib.util
+
 import pytest
 
-pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("torch") is None,
+    reason="requires torch",
+)
 
-from src.models.timesfm.config import TimesFMConfig
+
+@pytest.fixture
+def timesfm_config_cls():
+    from src.models.timesfm.config import TimesFMConfig
+
+    return TimesFMConfig
 
 
 class TestTimesFMConfigValidation:
-    def test_interval_mins_default_is_valid(self):
-        cfg = TimesFMConfig()
+    def test_interval_mins_default_is_valid(self, timesfm_config_cls):
+        cfg = timesfm_config_cls()
         assert cfg.interval_mins == 5
 
     @pytest.mark.parametrize("interval_mins", [0, -5])
-    def test_interval_mins_must_be_positive(self, interval_mins):
+    def test_interval_mins_must_be_positive(self, timesfm_config_cls, interval_mins):
         with pytest.raises(ValueError, match="interval_mins must be positive"):
-            TimesFMConfig(interval_mins=interval_mins)
+            timesfm_config_cls(interval_mins=interval_mins)


### PR DESCRIPTION
…ibility

make test-sundial was filtering with -k sundial and selecting zero tests (pytest exit code 5)

update Sundial target to run the intended model-safe subset

restore backward-compatible predict_batch dispatch when quantile_levels is not provided so existing _predict_batch(data, episode_col) overrides keep working