### PR TITLE
Fix NumPy 2 trapezoid compatibility in calibration metrics

### DIFF
--- a/scripts/visualization/plot_reliability_diagrams.py
+++ b/scripts/visualization/plot_reliability_diagrams.py
@@ -42,6 +42,14 @@ import pandas as pd
 
 from src.evaluation.metrics.probabilistic import compute_reliability_curve, compute_ece
 
+
+# NumPy 2 removed np.trapz in favor of np.trapezoid.
+def _trapezoid_area(y: np.ndarray, x: np.ndarray) -> float:
+    if hasattr(np, "trapezoid"):
+        return float(np.trapezoid(y, x))
+    return float(np.trapz(y, x))
+
+
 # ---------------------------------------------------------------------------
 # Aesthetics — consistent with other visualisation scripts
 # ---------------------------------------------------------------------------
@@ -257,7 +265,7 @@ def plot_main_body(
         agg_empirical = weighted_emp / total_n
 
         # ECE from the aggregated curve
-        agg_ece = float(np.trapz(np.abs(agg_empirical - nominal_ref), nominal_ref))
+        agg_ece = _trapezoid_area(np.abs(agg_empirical - nominal_ref), nominal_ref)
 
         datasets_used = ", ".join(
             DATASET_LABELS.get(d, d) for d in sorted(model_data.keys())

--- a/src/evaluation/metrics/probabilistic.py
+++ b/src/evaluation/metrics/probabilistic.py
@@ -683,4 +683,9 @@ def compute_ece(
     nominal, empirical = compute_reliability_curve(
         quantile_forecasts_batch, actuals_batch, quantile_levels
     )
-    return float(np.trapz(np.abs(empirical - nominal), nominal))
+    # NumPy 2 removed np.trapz in favor of np.trapezoid.
+    if hasattr(np, "trapezoid"):
+        area = np.trapezoid(np.abs(empirical - nominal), nominal)
+    else:
+        area = np.trapz(np.abs(empirical - nominal), nominal)
+    return float(area)


### PR DESCRIPTION
## Summary
- fix NumPy 2 compatibility by replacing direct `np.trapz` calls with a version-safe `np.trapezoid`/`np.trapz` fallback
- apply this in:
  - `src/evaluation/metrics/probabilistic.py` (`compute_ece`)
  - `scripts/visualization/plot_reliability_diagrams.py` (aggregated ECE)

## Why
Open PRs #394 and #398 are currently blocked by failing tests caused by `AttributeError: module 'numpy' has no attribute 'trapz'`.

## Validation
- `pytest -q tests/evaluation/test_probabilistic_metrics.py`
- Result: `62 passed`