### PR TITLE
Add nocturnal grand-summary analysis modules and scripts

### DIFF
--- a/scripts/analysis/build_best_episode_classification.py
+++ b/scripts/analysis/build_best_episode_classification.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Build the best-runs episode-classification breakdown.
+
+For every (model × dataset × cov_bucket) best run under a given holdout
+ablation, computes pooled AUROC / AUPRC for the binary task
+
+    y_ep = 1{ any forecast-window step has actual BG < 3.9 mmol/L }
+
+using **two** per-episode score variants:
+
+    s_ep^max  = max_t  P(BG_t < 3.9)
+    s_ep^mean = mean_t P(BG_t < 3.9)
+
+Output: ``<output_dir>/best_runs_episode_classification_<ablation>[_Nctx].csv``
+with parallel ``*_max`` / ``*_mean`` metric columns.
+
+Example::
+
+    python scripts/analysis/build_best_episode_classification.py --context-length 512
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Allow running from the repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.episode_classification import (  # noqa: E402
+    build_best_episode_classification,
+)
+from src.experiments.nocturnal.grand_summary import DATASETS  # noqa: E402
+
+DEFAULT_SUMMARIES = (
+    "experiments/nocturnal_forecasting/summary.csv",
+    "experiments/nocturnal_forecasting_ctx_ablation/summary.csv",
+)
+DEFAULT_OUTPUT_DIR = "results/grand_summary"
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--summary-csv", action="append", default=None)
+    p.add_argument("--config-dir", type=str, default=DEFAULT_CONFIG_DIR)
+    p.add_argument("--datasets", nargs="+", default=list(DATASETS))
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument("--forecast-length", type=int, default=96)
+    p.add_argument(
+        "--context-length",
+        type=int,
+        default=None,
+        help="If set, restrict to runs at this context length (e.g. 512).",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    summary_paths = args.summary_csv or list(DEFAULT_SUMMARIES)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    df = build_best_episode_classification(
+        summary_paths=summary_paths,
+        config_dir=args.config_dir,
+        datasets=args.datasets,
+        ctx_filter=args.context_length,
+        forecast_filter=args.forecast_length,
+    )
+
+    ablation = Path(args.config_dir).name
+    suffix = f"_{args.context_length}ctx" if args.context_length else ""
+    out_path = out_dir / f"best_runs_episode_classification_{ablation}{suffix}.csv"
+    df.to_csv(out_path, index=False)
+
+    print()
+    print("=" * 80)
+    print(
+        f"BEST-RUN EPISODE CLASSIFICATION (any-step hypo<3.9)  "
+        f"config_dir={args.config_dir}"
+    )
+    print("=" * 80)
+    if df.empty:
+        print("(no rows)")
+    else:
+        cols = [
+            "model_class",
+            "model",
+            "dataset",
+            "cov_bucket",
+            "split_type",
+            "n_episodes",
+            "n_pos",
+            "base_rate",
+            "auroc_max",
+            "auroc_mean",
+            "auprc_max",
+            "auprc_mean",
+            "auprc_skill_max",
+            "auprc_skill_mean",
+        ]
+        cols = [c for c in cols if c in df.columns]
+        # Drop the all-NaN deterministic rows from console output (still in CSV).
+        view = df.dropna(subset=["auroc_max"])
+        if view.empty:
+            print("(no probabilistic runs to display)")
+        else:
+            print(view[cols].to_string(index=False, float_format=lambda v: f"{v:.3f}"))
+    print(f"\nWrote {out_path.resolve()} ({len(df)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/build_best_split_breakdown.py
+++ b/scripts/analysis/build_best_split_breakdown.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Build the best-runs split-breakdown CSV.
+
+For each (model × dataset × cov_bucket) best run under the requested
+holdout ablation (default ``configs/data/holdout_10pct``), re-aggregates
+its per-episode metrics separately for the patient-holdout vs
+temporal-holdout subsets.
+
+Output: ``<output_dir>/best_runs_split_breakdown_<ablation>[_512ctx].csv``.
+
+Example::
+
+    python scripts/analysis/build_best_split_breakdown.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Allow running from the repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.grand_summary import DATASETS  # noqa: E402
+from src.experiments.nocturnal.grand_summary_split import (  # noqa: E402
+    build_best_split_breakdown,
+)
+
+DEFAULT_SUMMARIES = (
+    "experiments/nocturnal_forecasting/summary.csv",
+    "experiments/nocturnal_forecasting_ctx_ablation/summary.csv",
+)
+DEFAULT_OUTPUT_DIR = "results/grand_summary"
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--summary-csv", action="append", default=None)
+    p.add_argument("--config-dir", type=str, default=DEFAULT_CONFIG_DIR)
+    p.add_argument("--datasets", nargs="+", default=list(DATASETS))
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument("--forecast-length", type=int, default=96)
+    p.add_argument(
+        "--context-length",
+        type=int,
+        default=None,
+        help="If set, restrict to runs at this context length (e.g. 512).",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    summary_paths = args.summary_csv or list(DEFAULT_SUMMARIES)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    df = build_best_split_breakdown(
+        summary_paths=summary_paths,
+        config_dir=args.config_dir,
+        datasets=args.datasets,
+        ctx_filter=args.context_length,
+        forecast_filter=args.forecast_length,
+    )
+
+    ablation = Path(args.config_dir).name
+    suffix = f"_{args.context_length}ctx" if args.context_length else ""
+    out_path = out_dir / f"best_runs_split_breakdown_{ablation}{suffix}.csv"
+    df.to_csv(out_path, index=False)
+
+    print()
+    print("=" * 80)
+    print(f"BEST-RUN SPLIT BREAKDOWN (config_dir={args.config_dir})")
+    print("=" * 80)
+    if df.empty:
+        print("(no rows)")
+    else:
+        cols = [
+            "model_class",
+            "model",
+            "dataset",
+            "cov_bucket",
+            "split_type",
+            "n_patients",
+            "n_episodes",
+            "n_episodes_with_hypo",
+            "rmse",
+            "wql",
+            "brier_3_9",
+        ]
+        cols = [c for c in cols if c in df.columns]
+        print(df[cols].to_string(index=False, float_format=lambda v: f"{v:.3f}"))
+    print(f"\nWrote {out_path.resolve()} ({len(df)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/build_dataset_cohort_variance.py
+++ b/scripts/analysis/build_dataset_cohort_variance.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Build the three-way cohort variance/stats CSV.
+
+For each dataset under a holdout ablation (default
+``configs/data/holdout_10pct``), reports BG distribution stats for:
+
+  * patient_holdout  – patients in YAML's ``patient_config.holdout_patients``
+                       (entirely held out)
+  * temporal_holdout – tail-end of the non-holdout patients
+                       (the temporal split in the hybrid holdout)
+  * temporal_train   – the rest (the actual training data)
+
+Columns:
+  ``cohort, dataset, n_patients, n_rows, n_episodes, n_episodes_with_hypo,
+   hypo_rate, mean_bg, std_bg, mean_min_bg``
+
+Episodes are built by :func:`build_midnight_episodes` with the default
+context/forecast lengths used by the headline analysis (512 / 96), so
+counts are directly comparable to ``dataset_holdout_characteristics.csv``.
+``mean_min_bg`` is the average per-episode minimum BG across the forecast
+window, matching how ``has_hypo`` is defined.
+
+Output: ``<output_dir>/dataset_cohort_variance.csv``.
+
+Example::
+
+    python scripts/analysis/build_dataset_cohort_variance.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Allow running from the repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.grand_summary import DATASETS  # noqa: E402
+from src.experiments.nocturnal.holdout_split_analysis import (  # noqa: E402
+    build_three_way_cohort_stats,
+)
+
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+DEFAULT_OUTPUT_DIR = "results/grand_summary"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config-dir", type=str, default=DEFAULT_CONFIG_DIR)
+    p.add_argument("--datasets", nargs="+", default=list(DATASETS))
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument("--context-length", type=int, default=512)
+    p.add_argument("--forecast-length", type=int, default=96)
+    p.add_argument("--target-col", type=str, default="bg_mM")
+    p.add_argument("--interval-mins", type=int, default=5)
+    return p.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict] = []
+    for ds in args.datasets:
+        logging.info("Processing %s ...", ds)
+        rows.extend(
+            build_three_way_cohort_stats(
+                args.config_dir,
+                ds,
+                context_length=args.context_length,
+                forecast_length=args.forecast_length,
+                target_col=args.target_col,
+                interval_mins=args.interval_mins,
+            )
+        )
+
+    df = pd.DataFrame(rows)
+    out_path = out_dir / "dataset_cohort_variance.csv"
+    df.to_csv(out_path, index=False)
+
+    print()
+    print("=" * 80)
+    print(
+        f"DATASET COHORT VARIANCE STATS "
+        f"(config_dir={args.config_dir}, ctx={args.context_length}, fh={args.forecast_length})"
+    )
+    print("=" * 80)
+    if df.empty:
+        print("(no rows)")
+    else:
+        cols = [
+            "dataset",
+            "cohort",
+            "n_patients",
+            "n_episodes",
+            "n_episodes_with_hypo",
+            "hypo_rate",
+            "mean_bg",
+            "std_bg",
+            "mean_min_bg",
+        ]
+        print(df[cols].to_string(index=False, float_format=lambda v: f"{v:.3f}"))
+    print(f"\nWrote {out_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/build_dataset_holdout_characteristics.py
+++ b/scripts/analysis/build_dataset_holdout_characteristics.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Build the per-dataset holdout-characteristics CSV.
+
+For every dataset in a given holdout ablation (default
+``configs/data/holdout_10pct``), counts:
+
+  * how many patients fall in the patient- vs temporal-holdout split,
+  * how many midnight episodes were evaluated for each split, and
+  * how many of those episodes contained at least one true BG reading
+    below 3.9 mmol/L (the standard hypoglycemia threshold).
+
+The episode set is model-invariant for a given holdout config (it depends
+only on the data, not the forecaster), so we pick *one arbitrary* run per
+dataset that used the requested ``config_dir`` and read its
+``episodes.parquet`` + ``forecasts.npz``.
+
+Output: ``<output_dir>/dataset_holdout_characteristics.csv`` with columns
+``[ablation, dataset, split_type, n_patients, n_episodes,
+n_episodes_with_hypo, hypo_rate, source_run]``.
+
+Example::
+
+    python scripts/analysis/build_dataset_holdout_characteristics.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Allow running from the repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.grand_summary import DATASETS  # noqa: E402
+from src.experiments.nocturnal.holdout_split_analysis import (  # noqa: E402
+    SPLIT_PATIENT,
+    SPLIT_TEMPORAL,
+    load_run_episode_classification,
+)
+
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+DEFAULT_EXPERIMENTS_ROOTS = (
+    "experiments/nocturnal_forecasting",
+    "experiments/nocturnal_forecasting_ctx_ablation",
+)
+DEFAULT_OUTPUT_DIR = "results/grand_summary"
+
+log = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config-dir", type=str, default=DEFAULT_CONFIG_DIR)
+    p.add_argument(
+        "--experiments-root",
+        action="append",
+        default=None,
+        help=(
+            "Root directory holding nocturnal-forecasting runs (repeatable). "
+            f"Default: {' + '.join(DEFAULT_EXPERIMENTS_ROOTS)}"
+        ),
+    )
+    p.add_argument("--datasets", nargs="+", default=list(DATASETS))
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    return p.parse_args()
+
+
+def find_one_run_per_dataset(
+    experiments_roots: list[Path],
+    config_dir: str,
+    datasets: list[str],
+) -> dict[str, Path]:
+    """Walk experiment-config jsons; return the first matching run per dataset.
+
+    A run matches if its ``cli_args.config_dir == config_dir`` and its
+    ``cli_args.dataset`` is one of ``datasets`` and its run dir contains
+    both ``episodes.parquet`` and ``forecasts.npz``.
+    """
+    found: dict[str, Path] = {}
+    needed = set(datasets)
+    for root in experiments_roots:
+        if not root.exists():
+            log.warning("Experiments root %s does not exist; skipping.", root)
+            continue
+        for cfg_path in root.rglob("experiment_config.json"):
+            if not needed:
+                return found
+            try:
+                with cfg_path.open() as f:
+                    cfg = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+            cli = cfg.get("cli_args", {}) or {}
+            if str(cli.get("config_dir", "")) != config_dir:
+                continue
+            ds = str(cli.get("dataset", ""))
+            if ds not in needed:
+                continue
+            run_dir = cfg_path.parent
+            if not (run_dir / "episodes.parquet").exists():
+                continue
+            if not (run_dir / "forecasts.npz").exists():
+                continue
+            found[ds] = run_dir
+            needed.discard(ds)
+    return found
+
+
+def summarize_run(run_dir: Path, config_dir: str, dataset: str) -> list[dict]:
+    df = load_run_episode_classification(
+        run_dir, config_dir=config_dir, dataset=dataset
+    )
+    rows: list[dict] = []
+    for split in (SPLIT_PATIENT, SPLIT_TEMPORAL):
+        sub = df[df["split_type"] == split]
+        n_eps = int(len(sub))
+        n_pts = int(sub["patient_id"].nunique())
+        n_hypo = int(sub["has_hypo"].sum())
+        rows.append(
+            {
+                "ablation": Path(config_dir).name,
+                "dataset": dataset,
+                "split_type": split,
+                "n_patients": n_pts,
+                "n_episodes": n_eps,
+                "n_episodes_with_hypo": n_hypo,
+                "hypo_rate": (n_hypo / n_eps) if n_eps else float("nan"),
+                "source_run": str(run_dir),
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    experiments_roots = [
+        Path(r) for r in (args.experiments_root or DEFAULT_EXPERIMENTS_ROOTS)
+    ]
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = find_one_run_per_dataset(experiments_roots, args.config_dir, args.datasets)
+    missing = [ds for ds in args.datasets if ds not in runs]
+    if missing:
+        log.error(
+            "No matching run found for datasets %s under config_dir=%s",
+            missing,
+            args.config_dir,
+        )
+
+    rows: list[dict] = []
+    for ds in args.datasets:
+        if ds not in runs:
+            continue
+        log.info("Using %s for %s", runs[ds], ds)
+        rows.extend(summarize_run(runs[ds], args.config_dir, ds))
+
+    df = pd.DataFrame(rows)
+    out_path = out_dir / "dataset_holdout_characteristics.csv"
+    df.to_csv(out_path, index=False)
+
+    print()
+    print("=" * 80)
+    print(f"DATASET HOLDOUT CHARACTERISTICS (config_dir={args.config_dir})")
+    print("=" * 80)
+    if df.empty:
+        print("(no rows)")
+    else:
+        print(
+            df.drop(columns=["source_run"]).to_string(
+                index=False, float_format=lambda v: f"{v:.3f}"
+            )
+        )
+    print(f"\nWrote {out_path.resolve()}")
+    if missing:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/build_grand_summary.py
+++ b/scripts/analysis/build_grand_summary.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Build the grand summary tables (model properties + wide results matrix).
+
+Writes the following files under ``--output-dir``:
+    * model_properties.csv
+    * results_table_512ctx.csv          (main: context_length == 512)
+    * results_table_best_ctx.csv        (best across all context lengths)
+    * best_runs_long_512ctx.csv
+    * best_runs_long_best_ctx.csv
+    * missing_combinations_512ctx.csv
+    * missing_combinations_best_ctx.csv
+
+Also prints a markdown rendering of the 512-ctx table to stdout.
+
+Example::
+
+    python scripts/analysis/build_grand_summary.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Allow running from the repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.grand_summary import (  # noqa: E402
+    COV_BUCKET_LABELS,
+    DATASETS,
+    DEFAULT_METRICS,
+    MODEL_CLASS_LABELS,
+    VALID_COVARIATE_BUCKETS_BY_DATASET,
+    build_grand_summary,
+)
+
+DEFAULT_SUMMARIES = (
+    "experiments/nocturnal_forecasting/summary.csv",
+    "experiments/nocturnal_forecasting_ctx_ablation/summary.csv",
+)
+DEFAULT_OUTPUT_DIR = "results/grand_summary"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--summary-csv",
+        action="append",
+        default=None,
+        help=(
+            "Path to a summary.csv (repeatable). "
+            f"Default: {' + '.join(DEFAULT_SUMMARIES)}"
+        ),
+    )
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument(
+        "--datasets",
+        nargs="+",
+        default=list(DATASETS),
+        help="Datasets to include as super-columns.",
+    )
+    p.add_argument(
+        "--metrics",
+        nargs="+",
+        default=list(DEFAULT_METRICS),
+        help="Metric column order under each dataset.",
+    )
+    p.add_argument(
+        "--forecast-length",
+        type=int,
+        default=96,
+        help="Filter rows to this forecast horizon (default: 96).",
+    )
+    return p.parse_args()
+
+
+def _flatten_columns(wide: pd.DataFrame) -> pd.DataFrame:
+    """Turn the (dataset, metric) MultiIndex columns into 'dataset__metric' for CSV."""
+    flat = wide.copy()
+    flat.columns = [f"{ds}__{m}" for ds, m in wide.columns]
+    return flat.reset_index()
+
+
+def _to_markdown(wide: pd.DataFrame, metrics: list[str]) -> str:
+    """Render the wide table as grouped markdown — one section per model class."""
+    if wide.empty:
+        return "_(no rows)_"
+
+    lines: list[str] = []
+    datasets = list(dict.fromkeys(ds for ds, _ in wide.columns))
+
+    # Header rows
+    super_header = "| Model | Variant | " + " | ".join(
+        f"**{ds}**" + " |" * (len(metrics) - 1) for ds in datasets
+    )
+    sub_header = "| | | " + " | ".join(metrics * len(datasets)) + " |"
+    sep = "|---|---|" + "---|" * (len(metrics) * len(datasets))
+    lines.append(
+        super_header + " |" if not super_header.endswith("|") else super_header
+    )
+    lines.append(sub_header)
+    lines.append(sep)
+
+    last_class = None
+    for (cls, model, bucket), row in wide.iterrows():
+        if cls != last_class:
+            lines.append(
+                f"| **{MODEL_CLASS_LABELS.get(cls, cls)}** | | "
+                + " | ".join([""] * (len(metrics) * len(datasets)))
+                + " |"
+            )
+            last_class = cls
+        cells = []
+        for ds in datasets:
+            for m in metrics:
+                v = row.get((ds, m), float("nan"))
+                cells.append("—" if pd.isna(v) else f"{v:.3f}")
+        lines.append(
+            f"| {model} | {COV_BUCKET_LABELS.get(bucket, bucket)} | "
+            + " | ".join(cells)
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    summary_paths = args.summary_csv or list(DEFAULT_SUMMARIES)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Variant 1: 512-ctx fair-comparison table
+    # ------------------------------------------------------------------
+    res_512 = build_grand_summary(
+        summary_paths=summary_paths,
+        datasets=args.datasets,
+        metrics=args.metrics,
+        ctx_filter=512,
+        forecast_filter=args.forecast_length,
+    )
+    _flatten_columns(res_512["results_wide"]).to_csv(
+        out_dir / "results_table_512ctx.csv", index=False
+    )
+    res_512["best_runs_long"].to_csv(out_dir / "best_runs_long_512ctx.csv", index=False)
+    res_512["missing_combinations"].to_csv(
+        out_dir / "missing_combinations_512ctx.csv", index=False
+    )
+    res_512["misplaced_combinations"].to_csv(
+        out_dir / "misplaced_combinations_512ctx.csv", index=False
+    )
+    res_512["model_properties"].to_csv(out_dir / "model_properties.csv", index=False)
+
+    # ------------------------------------------------------------------
+    # Variant 2: best-across-context-lengths
+    # ------------------------------------------------------------------
+    res_best = build_grand_summary(
+        summary_paths=summary_paths,
+        datasets=args.datasets,
+        metrics=args.metrics,
+        ctx_filter=None,
+        forecast_filter=args.forecast_length,
+    )
+    _flatten_columns(res_best["results_wide"]).to_csv(
+        out_dir / "results_table_best_ctx.csv", index=False
+    )
+    res_best["best_runs_long"].to_csv(
+        out_dir / "best_runs_long_best_ctx.csv", index=False
+    )
+    res_best["missing_combinations"].to_csv(
+        out_dir / "missing_combinations_best_ctx.csv", index=False
+    )
+    res_best["misplaced_combinations"].to_csv(
+        out_dir / "misplaced_combinations_best_ctx.csv", index=False
+    )
+
+    # ------------------------------------------------------------------
+    # Console report
+    # ------------------------------------------------------------------
+    print()
+    print("=" * 80)
+    print(
+        f"GRAND RESULTS TABLE — context_length=512, forecast_length={args.forecast_length}"
+    )
+    print("=" * 80)
+    print(_to_markdown(res_512["results_wide"], args.metrics))
+    print()
+    print("=" * 80)
+    print(f"MISSING COMBINATIONS (512-ctx, fh={args.forecast_length})")
+    print("=" * 80)
+    miss = res_512["missing_combinations"]
+    if miss.empty:
+        print("  (none — every capable model × dataset × bucket has a run)")
+    else:
+        for cls, sub in miss.groupby("model_class", sort=False):
+            print(f"\n  [{MODEL_CLASS_LABELS.get(cls, cls)}]")
+            for _, r in sub.iterrows():
+                print(f"    - {r['model']:<32} {r['dataset']:<18} {r['cov_bucket']}")
+
+    print()
+    print("=" * 80)
+    print(f"MISPLACED COMBINATIONS (512-ctx, fh={args.forecast_length})")
+    print("(runs recorded in a bucket not valid for that dataset)")
+    print(
+        f"  Dataset covariate availability: { {k: sorted(v) for k, v in VALID_COVARIATE_BUCKETS_BY_DATASET.items()} }"
+    )
+    print("=" * 80)
+    mispl = res_512["misplaced_combinations"]
+    if mispl.empty:
+        print("  (none — all covariate runs are in the correct dataset bucket)")
+    else:
+        for cls, sub in mispl.groupby("model_class", sort=False):
+            print(f"\n  [{MODEL_CLASS_LABELS.get(cls, cls)}]")
+            for _, r in sub.iterrows():
+                print(
+                    f"    ! {r['model']:<32} {r['dataset']:<18} "
+                    f"{r['cov_bucket']:<12} covariates=({r['cov_variant']})"
+                )
+    print()
+    print(f"Outputs written to: {out_dir.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/compute_cumrmse_by_timestep.py
+++ b/scripts/analysis/compute_cumrmse_by_timestep.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""
+Compute per-episode cumulative RMSE at multiple forecast horizons for all
+models and datasets, then write results/analysis/cumrmse_by_timestep.csv.
+
+For each (model, dataset) pair, the *best* available run with a forecasts.npz
+is used (lowest overall RMSE from results_summary.json).
+
+Horizon checkpoints (minutes → steps at 5-min cadence):
+  15 min = 3 steps, 30 = 6, 60 = 12, 120 = 24, 240 = 48, 360 = 72, 480 = 96
+
+Per-episode cumRMSE at horizon k:
+    cumRMSE_i(k) = sqrt( mean_{t=1..k}( (y_{i,t} - ŷ_{i,t})^2 ) )
+
+The median forecast (q=0.5, index 4 in [0.1…0.9]) is used as ŷ.
+
+Output columns:
+    dataset, model,
+    15min_mean, 30min_mean, 60min_mean, 120min_mean, 240min_mean, 360min_mean, 480min_mean,
+    15min_std,  30min_std,  60min_std,  120min_std,  240min_std,  360min_std,  480min_std
+
+Usage:
+    python scripts/analysis/compute_cumrmse_by_timestep.py
+    python scripts/analysis/compute_cumrmse_by_timestep.py --out results/analysis/cumrmse_by_timestep.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DATASETS = ["aleppo_2017", "brown_2019", "lynch_2022", "tamborlane_2008"]
+
+# Models to include, in display order.
+# Groups: foundation models first, then deep-learning supervised.
+MODELS = [
+    "chronos2",
+    "moirai",
+    "timesfm",
+    "ttm",
+    "toto",
+    "moment",
+    "sundial",
+    "tft",
+    "deepar",
+    "timegrad",
+    "tide",
+    "patchtst",
+]
+
+# Horizon steps (5-min cadence) → column labels
+HORIZONS: list[tuple[int, str]] = [
+    (3, "15min"),
+    (6, "30min"),
+    (12, "60min"),
+    (24, "120min"),
+    (48, "240min"),
+    (72, "360min"),
+    (96, "480min"),
+]
+
+# Median quantile index in [0.1, 0.2, …, 0.9]
+MEDIAN_IDX = 4  # q=0.5
+
+# ---------------------------------------------------------------------------
+# TiDE covariate-exclusion: skip runs that used known (future) covariates.
+# Runs whose cov_bucket matches any of these are excluded for TiDE.
+# ---------------------------------------------------------------------------
+TIDE_EXCLUDED_COV_BUCKETS = {"iob", "iob_cob", "cob"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rmse_from_npz(run_dir: Path) -> float | None:
+    """
+    Compute overall RMSE from scratch using the median forecast in forecasts.npz.
+    This is the same computation used for the output values, ensuring run
+    selection and reported metrics are always consistent.
+    """
+    npz_path = run_dir / "forecasts.npz"
+    if not npz_path.exists():
+        return None
+    try:
+        npz = np.load(npz_path)
+        actuals = npz["actuals"]  # (n_eps, fh)
+        q_fc = npz["quantile_forecasts"]  # (n_eps, 9, fh) or (0,0,0)
+        if q_fc.ndim == 3 and q_fc.shape[1] > 0:
+            median_fc = q_fc[:, MEDIAN_IDX, :]
+        else:
+            median_fc = npz["predictions"]
+        return float(np.sqrt(np.mean((actuals - median_fc) ** 2)))
+    except Exception:
+        return None
+
+
+def _cov_bucket(run_dir: Path) -> str:
+    """Return cov_bucket from results_summary.json, or '' if missing."""
+    summary = run_dir / "results_summary.json"
+    if not summary.exists():
+        return ""
+    try:
+        with open(summary) as f:
+            d = json.load(f)
+        return str(d.get("cov_bucket", ""))
+    except Exception:
+        return ""
+
+
+def find_best_run(model: str, dataset: str) -> Path | None:
+    """
+    Scan experiments/nocturnal_forecasting/512ctx_96fh/<model>/ for runs
+    that (a) match *dataset*, (b) have a forecasts.npz, and optionally
+    (c) pass the TiDE known-covariate exclusion filter.
+
+    Returns the run directory with the lowest overall_rmse, or None.
+    """
+    model_dir = (
+        REPO_ROOT / "experiments" / "nocturnal_forecasting" / "512ctx_96fh" / model
+    )
+    if not model_dir.exists():
+        return None
+
+    best_rmse = float("inf")
+    best_run: Path | None = None
+
+    for run_dir in sorted(model_dir.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        if dataset not in run_dir.name:
+            continue
+        if not (run_dir / "forecasts.npz").exists():
+            continue
+
+        # TiDE: skip runs trained with known covariates
+        if model == "tide":
+            cov = _cov_bucket(run_dir)
+            if cov in TIDE_EXCLUDED_COV_BUCKETS:
+                print(f"  [tide] Skipping {run_dir.name} (cov={cov})")
+                continue
+
+        rmse = _rmse_from_npz(run_dir)
+        if rmse is None:
+            continue
+
+        if rmse < best_rmse:
+            best_rmse = rmse
+            best_run = run_dir
+
+    return best_run
+
+
+def compute_cumrmse(actuals: np.ndarray, median_fc: np.ndarray) -> np.ndarray:
+    """
+    Parameters
+    ----------
+    actuals   : (n_episodes, fh)
+    median_fc : (n_episodes, fh)
+
+    Returns
+    -------
+    cumrmse : (n_episodes, fh)  — cumRMSE_i(k) for every k
+    """
+    sq_err = (actuals - median_fc) ** 2  # (n_eps, fh)
+    # cumulative mean of squared errors up to each step
+    cum_mean_sq = np.cumsum(sq_err, axis=1) / np.arange(1, sq_err.shape[1] + 1)
+    return np.sqrt(cum_mean_sq)  # (n_eps, fh)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_csv(out_path: Path) -> None:
+    fieldnames = (
+        ["dataset", "model", "total_episodes"]
+        + [f"{label}_mean" for _, label in HORIZONS]
+        + [f"{label}_std" for _, label in HORIZONS]
+    )
+
+    rows: list[dict] = []
+
+    for dataset in DATASETS:
+        for model in MODELS:
+            run_dir = find_best_run(model, dataset)
+            if run_dir is None:
+                print(f"  WARNING: no valid run found for {model}/{dataset} — skipped")
+                continue
+
+            rmse = _rmse_from_npz(run_dir)
+            print(f"  {model:12s}  {dataset:15s}  run={run_dir.name}  rmse={rmse:.4f}")
+
+            npz = np.load(run_dir / "forecasts.npz")
+            actuals = npz["actuals"]  # (n_eps, fh)
+            q_fc = npz[
+                "quantile_forecasts"
+            ]  # (n_eps, 9, fh) or (0,0,0) for point models
+
+            if q_fc.ndim == 3 and q_fc.shape[1] > 0:
+                median_fc = q_fc[:, MEDIAN_IDX, :]  # (n_eps, fh)
+            else:
+                # Point-only model (e.g. TTM, Moment) — use predictions directly
+                median_fc = npz["predictions"]  # (n_eps, fh)
+
+            cumrmse = compute_cumrmse(actuals, median_fc)  # (n_eps, fh)
+            n_episodes = cumrmse.shape[0]
+
+            row: dict = {
+                "dataset": dataset,
+                "model": model,
+                "total_episodes": n_episodes,
+            }
+            for step, label in HORIZONS:
+                col = cumrmse[:, step - 1]  # 0-indexed: step k → index k-1
+                row[f"{label}_mean"] = round(float(np.mean(col)), 4)
+                row[f"{label}_std"] = round(float(np.std(col)), 4)
+
+            rows.append(row)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"\nWrote {len(rows)} rows → {out_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--out",
+        default="results/analysis/cumrmse_by_timestep_all_models.csv",
+        help="Output CSV path (default: results/analysis/cumrmse_by_timestep_all_models.csv)",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    build_csv(Path(args.out))

--- a/scripts/analysis/count_episodes_by_gap_policy.py
+++ b/scripts/analysis/count_episodes_by_gap_policy.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+"""Count midnight episodes under different gap-fill tolerances per dataset.
+
+For each dataset, builds episodes with three policies:
+  * strict        – production default (max_bg_gap_steps=11 ≈ 55 min)
+  * gap_60min     – up to 12 consecutive missing 5-min steps (= 1 hour)
+  * theoretical   – an upper bound: count of calendar midnights in each
+                    patient's recording window minus 2 warmup days minus 1
+                    trailing day. Assumes "perfect data" (no gaps anywhere).
+
+Outputs a small CSV at ``results/grand_summary/episode_count_sensitivity.csv``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.data.versioning.dataset_registry import DatasetRegistry  # noqa: E402
+from src.evaluation.episode_builders import build_midnight_episodes  # noqa: E402
+
+DATASETS = ["aleppo_2017", "brown_2019", "lynch_2022", "tamborlane_2008"]
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+
+
+def _theoretical_per_patient(
+    pdf: pd.DataFrame, *, context_length: int, forecast_length: int, interval_mins: int
+) -> int:
+    """Count calendar midnights inside [first+ctx, last-fh) for one patient."""
+    if (
+        pdf.empty
+        or "datetime" not in pdf.columns
+        and not isinstance(pdf.index, pd.DatetimeIndex)
+    ):
+        return 0
+    if "datetime" in pdf.columns:
+        idx = pd.to_datetime(pdf["datetime"]).sort_values()
+    else:
+        idx = pd.DatetimeIndex(pdf.index).sort_values()
+    if len(idx) == 0:
+        return 0
+    dt = pd.Timedelta(minutes=interval_mins)
+    earliest = idx.min() + context_length * dt
+    latest = idx.max() - (forecast_length - 1) * dt
+    first_midnight = earliest.normalize()
+    if first_midnight < earliest:
+        first_midnight += pd.Timedelta(days=1)
+    last_midnight = latest.normalize()
+    if last_midnight < first_midnight:
+        return 0
+    return int((last_midnight - first_midnight).days) + 1
+
+
+def _build_count(
+    df: pd.DataFrame,
+    *,
+    max_bg_gap_steps: int,
+    context_length: int,
+    forecast_length: int,
+    target_col: str,
+    interval_mins: int,
+    patient_col: str,
+) -> int:
+    n = 0
+    for _, pdf in df.groupby(patient_col):
+        pdf = pdf.copy()
+        if not isinstance(pdf.index, pd.DatetimeIndex):
+            if "datetime" in pdf.columns:
+                pdf["datetime"] = pd.to_datetime(pdf["datetime"])
+                pdf = pdf.set_index("datetime").sort_index()
+            else:
+                continue
+        episodes, _ = build_midnight_episodes(
+            pdf,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            target_col=target_col,
+            covariate_cols=None,
+            interval_mins=interval_mins,
+            max_bg_gap_steps=max_bg_gap_steps,
+        )
+        for ep in episodes:
+            tgt = np.asarray(ep["target_bg"])
+            if len(tgt) >= forecast_length:
+                n += 1
+    return n
+
+
+def _theoretical_count(
+    df: pd.DataFrame,
+    *,
+    context_length: int,
+    forecast_length: int,
+    interval_mins: int,
+    patient_col: str,
+) -> int:
+    n = 0
+    for _, pdf in df.groupby(patient_col):
+        n += _theoretical_per_patient(
+            pdf,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            interval_mins=interval_mins,
+        )
+    return n
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config-dir", default=DEFAULT_CONFIG_DIR)
+    ap.add_argument("--datasets", nargs="+", default=DATASETS)
+    ap.add_argument("--context-length", type=int, default=512)
+    ap.add_argument("--forecast-length", type=int, default=96)
+    ap.add_argument("--interval-mins", type=int, default=5)
+    ap.add_argument("--target-col", default="bg_mM")
+    ap.add_argument("--patient-col", default="p_num")
+    ap.add_argument(
+        "--output",
+        default="results/grand_summary/episode_count_sensitivity.csv",
+    )
+    args = ap.parse_args()
+
+    registry = DatasetRegistry(holdout_config_dir=Path(args.config_dir))
+
+    rows = []
+    for ds in args.datasets:
+        train_data, holdout_data = registry.load_dataset_with_split(
+            ds, patient_col=args.patient_col
+        )
+        full = pd.concat([train_data, holdout_data], ignore_index=False)
+        n_pat = int(full[args.patient_col].nunique())
+        kw = dict(
+            context_length=args.context_length,
+            forecast_length=args.forecast_length,
+            target_col=args.target_col,
+            interval_mins=args.interval_mins,
+            patient_col=args.patient_col,
+        )
+        n_strict = _build_count(full, max_bg_gap_steps=11, **kw)
+        n_60 = _build_count(full, max_bg_gap_steps=12, **kw)
+        n_theoretical = _theoretical_count(
+            full,
+            context_length=args.context_length,
+            forecast_length=args.forecast_length,
+            interval_mins=args.interval_mins,
+            patient_col=args.patient_col,
+        )
+        rows.append(
+            {
+                "dataset": ds,
+                "n_patients": n_pat,
+                "strict_55min_gap_cap": n_strict,
+                "gap_60min_cap": n_60,
+                "theoretical_no_gaps": n_theoretical,
+                "strict_yield_vs_theoretical": (
+                    n_strict / n_theoretical if n_theoretical else float("nan")
+                ),
+                "gap60_yield_vs_theoretical": (
+                    n_60 / n_theoretical if n_theoretical else float("nan")
+                ),
+            }
+        )
+        print(rows[-1])
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(out, index=False)
+    print(f"\nWrote {out.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/plot_bg_histograms_by_split.py
+++ b/scripts/analysis/plot_bg_histograms_by_split.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+"""Plot per-dataset BG histograms for train, temporal-holdout and patient-holdout splits.
+
+Produces a 3-row x 4-column grid (rows=splits, cols=datasets) using bin edges
+np.arange(0, 22.1, 0.1) on the ``bg_mM`` column.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.data.versioning.dataset_registry import DatasetRegistry  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DATASETS = ["aleppo_2017", "brown_2019", "lynch_2022", "tamborlane_2008"]
+SPLITS = ["train", "temporal_holdout", "patient_holdout"]
+SPLIT_LABELS = {
+    "train": "Train",
+    "temporal_holdout": "Temporal",
+    "patient_holdout": "Patient",
+}
+DATASET_LABELS = {
+    "aleppo_2017": "REPLACE-BG",
+    "brown_2019": "DCLP3",
+    "lynch_2022": "IOBP2",
+    "tamborlane_2008": "Tamborlane",
+}
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+DEFAULT_OUTPUT = "results/grand_summary/bg_histograms_by_split.png"
+
+
+def _split_three_ways(
+    train_df: pd.DataFrame,
+    holdout_df: pd.DataFrame,
+    holdout_patients: set[str],
+    patient_col: str,
+) -> dict[str, pd.DataFrame]:
+    """Decompose the registry's (train, holdout) into the three semantic cohorts."""
+    holdout_df = holdout_df.copy()
+    holdout_df[patient_col] = holdout_df[patient_col].astype(str)
+    is_pat = holdout_df[patient_col].isin(holdout_patients)
+    return {
+        "train": train_df,
+        "temporal_holdout": holdout_df.loc[~is_pat],
+        "patient_holdout": holdout_df.loc[is_pat],
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config-dir", default=DEFAULT_CONFIG_DIR)
+    p.add_argument("--datasets", nargs="+", default=DATASETS)
+    p.add_argument("--target-col", default="bg_mM")
+    p.add_argument("--patient-col", default="p_num")
+    p.add_argument("--bin-min", type=float, default=2.0)
+    p.add_argument("--bin-max", type=float, default=22.0)
+    p.add_argument("--bin-width", type=float, default=0.5)
+    p.add_argument("--hypo-threshold", type=float, default=3.9)
+    p.add_argument("--hyper-threshold", type=float, default=10.0)
+    p.add_argument(
+        "--fig-width",
+        type=float,
+        default=6.75,
+        help="Figure width in inches (NeurIPS column width).",
+    )
+    p.add_argument("--fig-height", type=float, default=4.25)
+    p.add_argument("--output", default=DEFAULT_OUTPUT)
+    args = p.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s - %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        level=logging.INFO,
+    )
+
+    bins = np.arange(args.bin_min, args.bin_max + args.bin_width, args.bin_width)
+    registry = DatasetRegistry(holdout_config_dir=Path(args.config_dir))
+
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.titlesize": 8,
+            "axes.labelsize": 8,
+            "xtick.labelsize": 7,
+            "ytick.labelsize": 7,
+            "legend.fontsize": 7,
+            "axes.linewidth": 0.6,
+            "xtick.major.width": 0.6,
+            "ytick.major.width": 0.6,
+        }
+    )
+
+    n_rows, n_cols = len(SPLITS), len(args.datasets)
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(args.fig_width, args.fig_height),
+        sharex=True,
+        sharey="row",
+    )
+    if n_rows == 1:
+        axes = np.array([axes])
+    if n_cols == 1:
+        axes = axes.reshape(-1, 1)
+
+    thousands_fmt = mticker.FuncFormatter(
+        lambda x, _pos: f"{x/1000:g}k" if x >= 1000 else f"{x:g}"
+    )
+
+    for c, ds in enumerate(args.datasets):
+        logger.info("Loading %s", ds)
+        train_df, holdout_df = registry.load_dataset_with_split(
+            ds, patient_col=args.patient_col
+        )
+        config = registry.get_holdout_config(ds)
+        holdout_patients = set(
+            str(x)
+            for x in (
+                config.patient_config.holdout_patients
+                if config and config.patient_config
+                else []
+            )
+        )
+        cohorts = _split_three_ways(
+            train_df, holdout_df, holdout_patients, args.patient_col
+        )
+
+        for r, split_name in enumerate(SPLITS):
+            ax = axes[r, c]
+            df = cohorts[split_name]
+            vals = df[args.target_col].to_numpy()
+            vals = vals[np.isfinite(vals)]
+            n_pat = df[args.patient_col].astype(str).nunique() if len(df) else 0
+            counts, edges = np.histogram(vals, bins=bins)
+            centers = 0.5 * (edges[:-1] + edges[1:])
+            colors = np.where(
+                centers < args.hypo_threshold,
+                "tab:red",
+                np.where(centers >= args.hyper_threshold, "tab:orange", "steelblue"),
+            )
+            ax.bar(
+                centers,
+                counts,
+                width=args.bin_width,
+                color=colors,
+                edgecolor="none",
+                align="center",
+            )
+            ax.set_xlim(args.bin_min, args.bin_max)
+            ax.set_xticks(
+                np.arange(args.bin_min, args.bin_max + 1e-9, 2.0), minor=False
+            )
+            ax.set_xticks(np.arange(args.bin_min, args.bin_max + 1e-9, 1.0), minor=True)
+            ax.tick_params(axis="x", labelsize=6, pad=1.5)
+            ax.tick_params(axis="x", which="minor", length=2)
+            ax.tick_params(axis="x", which="major", length=3)
+            for lbl in ax.get_xticklabels():
+                lbl.set_rotation(0)
+            ax.yaxis.set_major_formatter(thousands_fmt)
+            ax.grid(True, axis="y", alpha=0.25, linewidth=0.4)
+            for spine in ("top", "right"):
+                ax.spines[spine].set_visible(False)
+            if r == 0:
+                ax.set_title(DATASET_LABELS.get(ds, ds))
+            if c == 0:
+                ax.set_ylabel(SPLIT_LABELS[split_name])
+            else:
+                ax.tick_params(axis="y", labelleft=False)
+            if r == n_rows - 1:
+                ax.set_xlabel("BG (mmol/L)")
+            ax.text(
+                0.97,
+                0.93,
+                f"CGM Count={len(vals)/1000000:.1f}M\nPatients={n_pat}",
+                transform=ax.transAxes,
+                ha="right",
+                va="top",
+                fontsize=6,
+                bbox=dict(
+                    boxstyle="round,pad=0.2", fc="white", ec="0.7", lw=0.4, alpha=0.85
+                ),
+            )
+
+    fig.tight_layout()
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    fig.savefig(out_path.with_suffix(".pdf"), bbox_inches="tight")
+    logger.info("Wrote %s", out_path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/plot_episode_classification_curves.py
+++ b/scripts/analysis/plot_episode_classification_curves.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Plot ROC and PR curves for the "any-step hypo" episode classification task.
+
+Two figures are produced:
+  * ``episode_classification_roc_<ablation>[_Nctx].png``
+  * ``episode_classification_pr_<ablation>[_Nctx].png``
+
+Layout: rows = probabilistic model (one curve set per model), columns = dataset.
+Per cell, four curves are overlaid: two splits (``patient`` / ``temporal``) ×
+two per-episode score variants (``max`` / ``mean``). Split is encoded by
+colour, score variant by linestyle (solid = max, dashed = mean).
+
+For each (model × dataset) we pick the ``cov_bucket`` with the highest mean
+``auroc_max`` across the two splits in the breakdown CSV produced by
+``scripts/analysis/build_best_episode_classification.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.metrics import precision_recall_curve, roc_curve
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.experiments.nocturnal.episode_classification import (  # noqa: E402
+    load_run_classification_data,
+)
+from src.experiments.nocturnal.grand_summary import DATASETS  # noqa: E402
+
+DEFAULT_BREAKDOWN = (
+    "results/grand_summary/best_runs_episode_classification_holdout_10pct_512ctx.csv"
+)
+DEFAULT_OUTPUT_DIR = "results/figures"
+DEFAULT_CONFIG_DIR = "configs/data/holdout_10pct"
+
+_SPLIT_COLOURS = {"patient": "tab:blue", "temporal": "tab:orange"}
+_VARIANT_LINESTYLES = {"max": "-", "mean": "--"}
+_VARIANTS = ("max", "mean")
+_SPLITS = ("patient", "temporal")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--breakdown-csv", type=str, default=DEFAULT_BREAKDOWN)
+    p.add_argument("--config-dir", type=str, default=DEFAULT_CONFIG_DIR)
+    p.add_argument("--output-dir", type=str, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument("--datasets", nargs="+", default=list(DATASETS))
+    p.add_argument(
+        "--context-suffix",
+        type=str,
+        default="512ctx",
+        help="Suffix used in the output filename (e.g. '512ctx').",
+    )
+    return p.parse_args()
+
+
+def _pick_best_buckets(df: pd.DataFrame) -> pd.DataFrame:
+    """For each (model, dataset), keep the cov_bucket with highest mean ``auroc_max``."""
+    df = df.dropna(subset=["auroc_max"]).copy()
+    mean_auroc = (
+        df.groupby(["model", "dataset", "cov_bucket"])["auroc_max"]
+        .mean()
+        .reset_index(name="mean_auroc")
+    )
+    idx = mean_auroc.groupby(["model", "dataset"])["mean_auroc"].idxmax()
+    best = mean_auroc.loc[idx, ["model", "dataset", "cov_bucket"]]
+    return df.merge(best, on=["model", "dataset", "cov_bucket"], how="inner")
+
+
+def _load_curves(rows: pd.DataFrame, config_dir: str) -> dict:
+    """Load (fpr, tpr) and (precision, recall) per (model, dataset, split, variant)."""
+    out: dict = {}
+    cache: dict[str, pd.DataFrame] = {}
+    for _, r in rows.iterrows():
+        run_path = str(r["run_path"])
+        if run_path not in cache:
+            try:
+                cache[run_path] = load_run_classification_data(
+                    run_path,
+                    config_dir=config_dir,
+                    dataset=str(r["dataset"]),
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                logging.warning("Skipping %s: %s", run_path, exc)
+                cache[run_path] = pd.DataFrame()
+                continue
+        df = cache[run_path]
+        if df.empty:
+            continue
+        sub = df[df["split_type"] == r["split_type"]]
+        y = sub["has_hypo"].to_numpy()
+        for variant in _VARIANTS:
+            s = sub[f"{variant}_phat"].to_numpy()
+            valid = ~np.isnan(s)
+            if not valid.any() or y[valid].sum() in (0, valid.sum()):
+                continue
+            fpr, tpr, _ = roc_curve(y[valid], s[valid])
+            prec, rec, _ = precision_recall_curve(y[valid], s[valid])
+            out[(r["model"], r["dataset"], r["split_type"], variant)] = {
+                "fpr": fpr,
+                "tpr": tpr,
+                "precision": prec,
+                "recall": rec,
+                "base_rate": float(y[valid].mean()),
+                "auroc": float(r[f"auroc_{variant}"]),
+                "auprc": float(r[f"auprc_{variant}"]),
+                "cov_bucket": str(r["cov_bucket"]),
+            }
+    return out
+
+
+def _make_grid(curves: dict, models: list[str], datasets: list[str], kind: str):
+    n_rows, n_cols = len(models), len(datasets)
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(2.6 * n_cols + 1.0, 2.4 * n_rows + 0.8),
+        squeeze=False,
+        sharex=True,
+        sharey=True,
+    )
+    for i, model in enumerate(models):
+        for j, dataset in enumerate(datasets):
+            ax = axes[i][j]
+            cell_curves = {
+                (split, variant): curves.get((model, dataset, split, variant))
+                for split in _SPLITS
+                for variant in _VARIANTS
+            }
+            cov_bucket = next(
+                (c["cov_bucket"] for c in cell_curves.values() if c is not None),
+                None,
+            )
+            base_rate = next(
+                (c["base_rate"] for c in cell_curves.values() if c is not None),
+                None,
+            )
+            if kind == "roc":
+                ax.plot([0, 1], [0, 1], color="grey", lw=0.6, ls=":")
+            elif kind == "pr" and base_rate is not None:
+                ax.axhline(base_rate, color="grey", lw=0.6, ls=":")
+            for (split, variant), c in cell_curves.items():
+                if c is None:
+                    continue
+                colour = _SPLIT_COLOURS[split]
+                ls = _VARIANT_LINESTYLES[variant]
+                if kind == "roc":
+                    ax.plot(
+                        c["fpr"],
+                        c["tpr"],
+                        color=colour,
+                        lw=1.2,
+                        ls=ls,
+                        label=f"{split} {variant} (AUC={c['auroc']:.2f})",
+                    )
+                else:
+                    ax.plot(
+                        c["recall"],
+                        c["precision"],
+                        color=colour,
+                        lw=1.2,
+                        ls=ls,
+                        label=f"{split} {variant} (AP={c['auprc']:.2f})",
+                    )
+            ax.set_xlim(0, 1)
+            ax.set_ylim(0, 1)
+            ax.tick_params(labelsize=7)
+            if i == 0:
+                ax.set_title(dataset, fontsize=9)
+            if j == 0:
+                ax.set_ylabel(
+                    f"{model}\n{'TPR' if kind == 'roc' else 'precision'}",
+                    fontsize=8,
+                )
+            if i == n_rows - 1:
+                ax.set_xlabel("FPR" if kind == "roc" else "recall", fontsize=8)
+            if cov_bucket is not None:
+                ax.text(
+                    0.98,
+                    0.02,
+                    cov_bucket,
+                    transform=ax.transAxes,
+                    fontsize=6,
+                    ha="right",
+                    va="bottom",
+                    color="dimgrey",
+                )
+            if any(c is not None for c in cell_curves.values()):
+                ax.legend(
+                    fontsize=6, loc="upper left" if kind == "roc" else "upper right"
+                )
+            else:
+                ax.set_facecolor("#f7f7f7")
+    fig.suptitle(
+        "Episode-level any-step hypoglycemia "
+        + ("ROC curves" if kind == "roc" else "precision–recall curves"),
+        fontsize=11,
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    return fig
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    df = pd.read_csv(args.breakdown_csv)
+    if "run_path" not in df.columns:
+        raise SystemExit(
+            f"{args.breakdown_csv} missing run_path column; rebuild with the "
+            "current build_best_episode_classification.py."
+        )
+    df = df[df["dataset"].isin(args.datasets)]
+    rows = _pick_best_buckets(df)
+    if rows.empty:
+        raise SystemExit("No probabilistic rows after filtering.")
+
+    curves = _load_curves(rows, args.config_dir)
+    if not curves:
+        raise SystemExit("No curves produced.")
+
+    models = sorted({m for (m, _, _, _) in curves})
+    datasets = [
+        d
+        for d in args.datasets
+        if any(
+            (m, d, s, v) in curves for m in models for s in _SPLITS for v in _VARIANTS
+        )
+    ]
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    suffix = f"_{args.context_suffix}" if args.context_suffix else ""
+
+    for kind in ("roc", "pr"):
+        fig = _make_grid(curves, models, datasets, kind)
+        out_path = out_dir / f"episode_classification_{kind}{suffix}.png"
+        fig.savefig(out_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Wrote {out_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/relocate_768ctx_results.py
+++ b/scripts/analysis/relocate_768ctx_results.py
@@ -1,0 +1,103 @@
+"""
+relocate_768ctx_results.py
+
+One-shot script that:
+1. Walks experiments/nocturnal_forecasting/512ctx_96fh/{deepar,patchtst,tft}/
+2. Reads experiment_config.json in each run dir
+3. Moves 768-ctx runs to experiments/nocturnal_forecasting/768ctx_96fh/{model}/
+4. Moves 05_bg_high_lr TFT runs to experiments/nocturnal_forecasting/_bad_runs_archive/tft/
+
+Done-file entries are NOT modified — they are keyed by stem|dataset, not path.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+EXPERIMENT_ROOT = Path("experiments/nocturnal_forecasting")
+SRC_DIR = EXPERIMENT_ROOT / "512ctx_96fh"
+DST_768_DIR = EXPERIMENT_ROOT / "768ctx_96fh"
+BAD_RUNS_DIR = EXPERIMENT_ROOT / "_bad_runs_archive" / "tft"
+
+# Config stems that indicate a 768-ctx run (matched as substring of model_config path)
+LONG_CTX_STEMS = {
+    "deepar": ["02_long_ctx", "11_big"],
+    "patchtst": ["04_long_ctx"],
+    "tft": ["02_bg_long_ctx", "08_iob_long_ctx"],
+}
+
+# Config stems that should be archived as bad runs
+BAD_STEMS = {
+    "tft": ["05_bg_high_lr"],
+}
+
+
+def get_model_config(run_dir: Path) -> str:
+    config_file = run_dir / "experiment_config.json"
+    if not config_file.exists():
+        return ""
+    with open(config_file) as f:
+        data = json.load(f)
+    cli_args = data.get("cli_args", {})
+    if isinstance(cli_args, dict):
+        return cli_args.get("model_config", "")
+    return data.get("model_config", "")
+
+
+def move_run(src: Path, dst_parent: Path) -> None:
+    dst_parent.mkdir(parents=True, exist_ok=True)
+    dst = dst_parent / src.name
+    if dst.exists():
+        print(f"  [SKIP] destination already exists: {dst}")
+        return
+    shutil.move(str(src), str(dst))
+    print(f"  [MOVED] {src} -> {dst}")
+
+
+def main():
+    moved_768 = 0
+    moved_bad = 0
+
+    for model in ["deepar", "patchtst", "tft"]:
+        model_src = SRC_DIR / model
+        if not model_src.exists():
+            print(f"[WARN] {model_src} does not exist, skipping.")
+            continue
+
+        long_ctx_stems = LONG_CTX_STEMS.get(model, [])
+        bad_stems = BAD_STEMS.get(model, [])
+
+        run_dirs = sorted(p for p in model_src.iterdir() if p.is_dir())
+        print(f"\n=== {model}: {len(run_dirs)} run dirs ===")
+
+        for run_dir in run_dirs:
+            model_config = get_model_config(run_dir)
+            if not model_config:
+                print(f"  [WARN] No model_config found in {run_dir}, skipping.")
+                continue
+
+            # Check bad runs first
+            is_bad = any(stem in model_config for stem in bad_stems)
+            if is_bad:
+                move_run(run_dir, BAD_RUNS_DIR)
+                moved_bad += 1
+                continue
+
+            # Check 768-ctx runs
+            is_long_ctx = any(stem in model_config for stem in long_ctx_stems)
+            if is_long_ctx:
+                move_run(run_dir, DST_768_DIR / model)
+                moved_768 += 1
+
+    print(
+        f"\nDone. Moved {moved_768} runs to 768ctx_96fh, {moved_bad} runs to _bad_runs_archive."
+    )
+
+
+if __name__ == "__main__":
+    import os
+
+    # Run from repo root
+    repo_root = Path(__file__).resolve().parents[2]
+    os.chdir(repo_root)
+    main()

--- a/src/experiments/base/experiment.py
+++ b/src/experiments/base/experiment.py
@@ -96,6 +96,9 @@ class ExperimentSummarizer(ABC):
         for ctx_fh_dir in sorted(self.experiment_dir.iterdir()):
             if not ctx_fh_dir.is_dir():
                 continue
+            if ctx_fh_dir.name.startswith("_"):
+                log.debug("Skipping reserved directory: %s", ctx_fh_dir)
+                continue
             for model_dir in sorted(ctx_fh_dir.iterdir()):
                 if not model_dir.is_dir():
                     continue

--- a/src/experiments/nocturnal/episode_classification.py
+++ b/src/experiments/nocturnal/episode_classification.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Episode-level classification of "any-step hypoglycemia" from existing runs.
+
+For each midnight-anchored episode we already store the actuals and the
+quantile forecasts (Tier 3 in ``forecasts.npz``).  This module derives a
+binary label and **two** continuous risk scores per episode:
+
+  * label      ``y_ep      = 1{ min_t actuals[t] < HYPO_THRESHOLD_MMOL }``
+  * score_max  ``s_ep^max  = max_t  P(BG_t < HYPO_THRESHOLD_MMOL)``
+  * score_mean ``s_ep^mean = mean_t P(BG_t < HYPO_THRESHOLD_MMOL)``
+
+then evaluates how well each score ranks the binary outcome with **AUROC**
+and **AUPRC** pooled per run/split.  Metric columns are suffixed
+``_max`` / ``_mean`` so both score variants appear in the same row of the
+output table.  AUROC is base-rate invariant; AUPRC is reported alongside
+its random-chance baseline (the base rate) and the skill score
+``AUPRC - base_rate``.
+
+Aggregation: pooled per (run × split_type).  No bootstrap CIs.
+
+Models that don't emit quantile forecasts (e.g. TTM, deterministic
+baselines) get ``NaN`` everywhere — the score is undefined for them.
+
+Module: experiments.nocturnal.episode_classification
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+from src.experiments.nocturnal.grand_summary import (
+    DATASETS,
+    MODEL_PROPERTIES,
+    attach_covariate_bucket,
+    dedupe,
+    load_summary,
+    pick_best,
+)
+from src.experiments.nocturnal.grand_summary_split import (
+    attach_config_dir,
+    _model_class,
+)
+from src.experiments.nocturnal.holdout_split_analysis import (
+    HYPO_THRESHOLD_MMOL,
+    SPLIT_PATIENT,
+    SPLIT_TEMPORAL,
+    classify_episodes,
+    load_holdout_patient_set,
+)
+
+log = logging.getLogger(__name__)
+
+_SPLITS: tuple[str, ...] = (SPLIT_PATIENT, SPLIT_TEMPORAL)
+
+
+# ---------------------------------------------------------------------------
+# Per-step hypo probability from the quantile CDF
+# ---------------------------------------------------------------------------
+
+
+def per_step_hypo_probability(
+    quantile_forecasts: np.ndarray,
+    quantile_levels: np.ndarray,
+    threshold: float = HYPO_THRESHOLD_MMOL,
+) -> np.ndarray:
+    """Estimate ``P(BG_t < threshold)`` at every (episode, step).
+
+    For each (episode, step) the quantile values are sorted along the
+    quantile axis and ``threshold`` is linearly interpolated against the
+    discrete CDF (BG values → cumulative probability), exactly matching the
+    semantics in :func:`src.evaluation.metrics.probabilistic.compute_brier_score`,
+    including the conservative ``[q_min, q_max]`` clamping at the tails.
+
+    Args:
+        quantile_forecasts: shape ``(n_episodes, n_quantiles, forecast_length)``.
+        quantile_levels:    shape ``(n_quantiles,)``, strictly increasing in
+                            (0, 1).
+        threshold:          BG threshold in mmol/L.
+
+    Returns:
+        Array of shape ``(n_episodes, forecast_length)`` of ``p_hat`` values
+        in ``[q_min, q_max]``.
+    """
+    qf = np.asarray(quantile_forecasts, dtype=np.float64)
+    q_arr = np.asarray(quantile_levels, dtype=np.float64)
+
+    if qf.ndim != 3:
+        raise ValueError(
+            f"quantile_forecasts must be 3D (n_eps, n_q, fh); got {qf.shape}"
+        )
+    if q_arr.ndim != 1 or q_arr.size != qf.shape[1]:
+        raise ValueError(
+            f"quantile_levels {q_arr.shape} incompatible with q axis {qf.shape[1]}"
+        )
+    if not np.all(np.diff(q_arr) > 0):
+        raise ValueError("quantile_levels must be strictly increasing.")
+
+    n_eps, n_q, fh = qf.shape
+    q_min, q_max = float(q_arr[0]), float(q_arr[-1])
+
+    # Sort BG values per (episode, step) so the per-(ep, step) "xp" is
+    # monotone-non-decreasing.
+    xs = np.sort(qf, axis=1)  # (n_eps, n_q, fh)
+
+    # Vectorised per-(ep, step) np.interp(threshold, xs, q_arr, left=q_min, right=q_max):
+    # find insertion index along the quantile axis.
+    idx = (xs < threshold).sum(axis=1)  # (n_eps, fh) ∈ [0, n_q]
+    idx_low = np.clip(idx - 1, 0, n_q - 1)
+    idx_high = np.clip(idx, 0, n_q - 1)
+
+    x_low = np.take_along_axis(xs, idx_low[:, None, :], axis=1)[:, 0, :]
+    x_high = np.take_along_axis(xs, idx_high[:, None, :], axis=1)[:, 0, :]
+    y_low = q_arr[idx_low]
+    y_high = q_arr[idx_high]
+
+    denom = x_high - x_low
+    with np.errstate(divide="ignore", invalid="ignore"):
+        frac = np.where(denom > 0, (threshold - x_low) / denom, 0.0)
+    p_hat = y_low + frac * (y_high - y_low)
+    # Tail clamping to match np.interp(..., left=q_min, right=q_max).
+    p_hat = np.where(idx == 0, q_min, p_hat)
+    p_hat = np.where(idx == n_q, q_max, p_hat)
+    return p_hat
+
+
+# ---------------------------------------------------------------------------
+# Per-run loader specialised for classification (skips episode parquet read
+# of arrays we don't need + reads quantile_forecasts from npz).
+# ---------------------------------------------------------------------------
+
+
+def _read_run_meta(run_path: Path) -> tuple[str, str] | tuple[None, None]:
+    cfg_path = run_path / "experiment_config.json"
+    if not cfg_path.exists():
+        return None, None
+    try:
+        with cfg_path.open() as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None, None
+    cli = cfg.get("cli_args", {}) or {}
+    cd = cli.get("config_dir")
+    ds = cli.get("dataset")
+    return (str(cd) if cd else None, str(ds) if ds else None)
+
+
+def load_run_classification_data(
+    run_path: str | Path,
+    config_dir: str | Path | None = None,
+    dataset: str | None = None,
+) -> pd.DataFrame:
+    """Load per-episode label + ``max_phat`` / ``mean_phat`` scores for one run.
+
+    Returns a DataFrame with columns:
+      ``patient_id, split_type, has_hypo, max_phat, mean_phat``
+
+    Both score columns are ``NaN`` for runs without ``quantile_forecasts``
+    (deterministic models).
+    """
+    run_path = Path(run_path)
+    parquet_path = run_path / "episodes.parquet"
+    npz_path = run_path / "forecasts.npz"
+    if not parquet_path.exists():
+        raise FileNotFoundError(parquet_path)
+    if not npz_path.exists():
+        raise FileNotFoundError(npz_path)
+
+    if config_dir is None or dataset is None:
+        cd, ds = _read_run_meta(run_path)
+        config_dir = config_dir or cd
+        dataset = dataset or ds
+        if config_dir is None or dataset is None:
+            raise ValueError(
+                f"{run_path} missing cli_args.config_dir/dataset; pass explicitly"
+            )
+
+    holdout_patients = load_holdout_patient_set(config_dir, dataset)
+
+    parquet_df = pd.read_parquet(parquet_path, columns=["patient_id"])
+
+    with np.load(npz_path, allow_pickle=False) as npz:
+        actuals = np.asarray(npz["actuals"])
+        q_forecasts = np.asarray(npz.get("quantile_forecasts", np.empty((0, 0, 0))))
+        q_levels = np.asarray(npz.get("quantile_levels", np.empty(0)))
+
+    if len(actuals) != len(parquet_df):
+        raise ValueError(
+            f"{run_path}: episodes.parquet has {len(parquet_df)} rows but "
+            f"forecasts.npz has {len(actuals)} — files are out of sync."
+        )
+
+    has_hypo = actuals.min(axis=1) < HYPO_THRESHOLD_MMOL
+
+    if q_forecasts.size == 0 or q_levels.size == 0:
+        max_phat = np.full(len(parquet_df), np.nan, dtype=np.float64)
+        mean_phat = np.full(len(parquet_df), np.nan, dtype=np.float64)
+    else:
+        if q_forecasts.shape[0] != len(parquet_df):
+            raise ValueError(
+                f"{run_path}: quantile_forecasts has {q_forecasts.shape[0]} "
+                f"rows, expected {len(parquet_df)}"
+            )
+        p_step = per_step_hypo_probability(q_forecasts, q_levels)
+        max_phat = p_step.max(axis=1)
+        mean_phat = p_step.mean(axis=1)
+
+    out = pd.DataFrame(
+        {
+            "patient_id": parquet_df["patient_id"].astype(str).to_numpy(),
+            "split_type": classify_episodes(parquet_df["patient_id"], holdout_patients),
+            "has_hypo": has_hypo,
+            "max_phat": max_phat,
+            "mean_phat": mean_phat,
+        }
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-split classification metrics
+# ---------------------------------------------------------------------------
+
+
+def episode_classification_metrics(
+    y_true: np.ndarray, scores: np.ndarray
+) -> dict[str, float]:
+    """Pooled classification metrics for a set of episodes.
+
+    Returns ``base_rate``, ``auroc``, ``auprc``, ``auprc_skill``,
+    ``n_episodes``, ``n_pos``, ``n_neg``.
+
+    ``auroc``/``auprc`` are ``NaN`` when scores are all-NaN (deterministic
+    model) or when one class is missing from ``y_true``.
+    """
+    y_true = np.asarray(y_true, dtype=bool)
+    scores = np.asarray(scores, dtype=np.float64)
+
+    n = int(y_true.size)
+    n_pos = int(y_true.sum())
+    n_neg = int(n - n_pos)
+    base_rate = float(n_pos / n) if n else float("nan")
+
+    out = {
+        "n_episodes": n,
+        "n_pos": n_pos,
+        "n_neg": n_neg,
+        "base_rate": base_rate,
+        "auroc": float("nan"),
+        "auprc": float("nan"),
+        "auprc_skill": float("nan"),
+    }
+    if n_pos == 0 or n_neg == 0:
+        return out
+    valid = ~np.isnan(scores)
+    if not valid.any():
+        return out
+    y_v = y_true[valid]
+    s_v = scores[valid]
+    if y_v.sum() == 0 or y_v.sum() == y_v.size:
+        return out
+    out["auroc"] = float(roc_auc_score(y_v, s_v))
+    out["auprc"] = float(average_precision_score(y_v, s_v))
+    # Skill vs always predicting the marginal: random AUPRC == base rate.
+    # Use the *valid-subset* base rate so skill is internally consistent.
+    sub_rate = float(y_v.mean())
+    out["auprc_skill"] = out["auprc"] - sub_rate
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-run aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_run_classification(
+    run_path: str | Path,
+    *,
+    model: str,
+    dataset: str,
+    cov_bucket: str,
+    config_dir: str,
+) -> list[dict]:
+    """One row per ``split_type`` of classification metrics for one run.
+
+    Each row carries both ``*_max`` and ``*_mean`` variants of AUROC, AUPRC,
+    and AUPRC skill so the two episode-score definitions can be compared
+    side-by-side. Counts (``n_episodes``, ``n_pos``, ``n_neg``,
+    ``base_rate``) are score-independent and reported once.
+    """
+    df = load_run_classification_data(run_path, config_dir=config_dir, dataset=dataset)
+    rows: list[dict] = []
+    for split in _SPLITS:
+        sub = df[df["split_type"] == split]
+        y = sub["has_hypo"].to_numpy()
+        m_max = episode_classification_metrics(y, sub["max_phat"].to_numpy())
+        m_mean = episode_classification_metrics(y, sub["mean_phat"].to_numpy())
+        shared = {k: m_max[k] for k in ("n_episodes", "n_pos", "n_neg", "base_rate")}
+        scored = {
+            "auroc_max": m_max["auroc"],
+            "auroc_mean": m_mean["auroc"],
+            "auprc_max": m_max["auprc"],
+            "auprc_mean": m_mean["auprc"],
+            "auprc_skill_max": m_max["auprc_skill"],
+            "auprc_skill_mean": m_mean["auprc_skill"],
+        }
+        rows.append(
+            {
+                "model": model,
+                "dataset": dataset,
+                "cov_bucket": cov_bucket,
+                "split_type": split,
+                "n_patients": int(sub["patient_id"].nunique()),
+                **shared,
+                **scored,
+                "run_path": str(run_path),
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Top-level pipeline (mirrors build_best_split_breakdown)
+# ---------------------------------------------------------------------------
+
+
+def build_best_episode_classification(
+    summary_paths: Sequence[str | Path],
+    config_dir: str,
+    *,
+    datasets: Sequence[str] = DATASETS,
+    ctx_filter: int | None = None,
+    forecast_filter: int | None = 96,
+) -> pd.DataFrame:
+    """Build the long-form best-runs episode-classification table.
+
+    Filters, dedupes, buckets, and picks best runs the same way as
+    :func:`grand_summary_split.build_best_split_breakdown`, then computes
+    AUROC/AUPRC for the binary "any-step hypo" task per (run × split).
+    """
+    raw = load_summary(summary_paths)
+    if forecast_filter is not None and "forecast_length" in raw.columns:
+        raw = raw[raw["forecast_length"] == forecast_filter]
+    if ctx_filter is not None and "context_length" in raw.columns:
+        raw = raw[raw["context_length"] == ctx_filter]
+    raw = raw[raw["model"].isin(MODEL_PROPERTIES)]
+    raw = raw[raw["dataset"].isin(list(datasets))]
+    raw = attach_config_dir(raw)
+    raw = raw[raw["config_dir"] == config_dir]
+    if raw.empty:
+        log.warning(
+            "No runs match config_dir=%s after filtering; returning empty frame.",
+            config_dir,
+        )
+        return pd.DataFrame()
+    deduped = dedupe(raw)
+    bucketed = attach_covariate_bucket(deduped)
+    best = pick_best(bucketed)
+
+    rows: list[dict] = []
+    for _, r in best.iterrows():
+        run_path = str(r["run_path"])
+        try:
+            split_rows = aggregate_run_classification(
+                run_path,
+                model=str(r["model"]),
+                dataset=str(r["dataset"]),
+                cov_bucket=str(r["cov_bucket"]),
+                config_dir=config_dir,
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            log.warning("Skipping %s: %s", run_path, exc)
+            continue
+        for sr in split_rows:
+            sr["model_class"] = _model_class(sr["model"])
+            sr["context_length"] = r.get("context_length")
+            sr["forecast_length"] = r.get("forecast_length")
+            rows.append(sr)
+    out = pd.DataFrame(rows)
+    if out.empty:
+        return out
+    out = out.sort_values(
+        ["model_class", "model", "dataset", "cov_bucket", "split_type"]
+    ).reset_index(drop=True)
+    lead = [
+        "model_class",
+        "model",
+        "dataset",
+        "cov_bucket",
+        "split_type",
+        "n_patients",
+        "n_episodes",
+        "n_pos",
+        "n_neg",
+        "base_rate",
+        "auroc_max",
+        "auroc_mean",
+        "auprc_max",
+        "auprc_mean",
+        "auprc_skill_max",
+        "auprc_skill_mean",
+    ]
+    rest = [c for c in out.columns if c not in lead]
+    out = out[[c for c in lead if c in out.columns] + rest]
+    return out
+
+
+__all__ = [
+    "aggregate_run_classification",
+    "build_best_episode_classification",
+    "episode_classification_metrics",
+    "load_run_classification_data",
+    "per_step_hypo_probability",
+]

--- a/src/experiments/nocturnal/grand_summary.py
+++ b/src/experiments/nocturnal/grand_summary.py
@@ -1,0 +1,741 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Grand summary aggregator for nocturnal forecasting evaluations.
+
+Builds a wide results table (super-columns = dataset, sub-columns = metric,
+row sections = model class) plus a model-property matrix and a long-form
+companion table of best runs.
+
+Inputs:
+    One or more `summary.csv` files produced by NocturnalSummarizer.
+Outputs (returned DataFrames; the CLI script writes them to disk):
+    * model_properties_df  -- architecture-level capabilities per model family.
+    * results_wide_df      -- best run per (model, dataset, cov_bucket).
+    * best_runs_long_df    -- tidy version of the wide table.
+    * missing_combos_df    -- (model, dataset, cov_bucket) cells that should
+      exist (per MODEL_PROPERTIES) but have no run.
+
+Module: experiments.nocturnal.grand_summary
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DATASETS: tuple[str, ...] = (
+    "aleppo_2017",
+    "brown_2019",
+    "lynch_2022",
+    "tamborlane_2008",
+)
+
+DEFAULT_METRICS: tuple[str, ...] = (
+    "rmse",
+    "wql",
+    "sharpness_50",
+    "coverage_50",
+    "sharpness_80",
+    "coverage_80",
+    "brier_3_9",
+    "dilate_g001",
+    "shape_g001",
+    "temporal_g001",
+)
+
+# Buckets for the "best version of each model" rows in the wide table.
+COV_BUCKETS: tuple[str, ...] = ("zero_shot", "bg_only", "iob", "iob_cob")
+
+COV_BUCKET_LABELS: dict[str, str] = {
+    "zero_shot": "Best Zero-Shot",
+    "bg_only": "Best BG-only",
+    "iob": "Best +IOB/InsulinAvail",
+    "iob_cob": "Best +IOB+COB",
+}
+
+# Dataset-specific covariate availability.
+# Each dataset only has a subset of clinical covariates available; only the
+# corresponding bucket can be legitimately populated for that dataset.
+# Runs in any other covariate bucket are flagged as MISPLACED.
+# Maximum covariate capability per dataset.  Store only the "highest" bucket
+# the dataset's data can support; `_expand_valid_buckets` derives the full set
+# of valid sub-buckets automatically (iob_cob ⊇ iob ⊇ bg_only).  bg_only and
+# zero_shot are always universally valid and need not be listed here.
+VALID_COVARIATE_BUCKETS_BY_DATASET: dict[str, frozenset[str]] = {
+    "aleppo_2017": frozenset({"iob_cob"}),  # IOB + COB both available
+    "brown_2019": frozenset({"iob"}),  # IOB only
+    "lynch_2022": frozenset({"iob"}),  # IOB only
+    "tamborlane_2008": frozenset(),  # BG-only; no clinical covariates
+}
+
+# Model class taxonomy. Order here drives row order in the wide table.
+MODEL_CLASS_ORDER: tuple[str, ...] = (
+    "naive",
+    "statistical",
+    "deep_learning",
+    "foundation",
+)
+
+MODEL_CLASS_LABELS: dict[str, str] = {
+    "naive": "Naive baselines",
+    "statistical": "Statistical",
+    "deep_learning": "Deep learning",
+    "foundation": "Foundation (pre-trained)",
+}
+
+# Architecture-level capabilities per model family.
+# Keys match the `model` column emitted by NocturnalSummarizer (multi-variant
+# models keep their `parent/variant` form, e.g. `statistical/AutoARIMA`).
+#
+# Booleans:
+#   zero_shot_capable       -- pretrained weights usable with no fine-tune?
+#   fine_tunable            -- supports per-dataset fine-tune in our pipeline?
+#   supports_past_covariates-- accepts past covariates (IOB / COB / IA)?
+#   univariate_only         -- forced to single channel?
+#   probabilistic           -- emits quantiles / sample paths?
+MODEL_PROPERTIES: dict[str, dict[str, Any]] = {
+    # ---- Naive baselines ----
+    # Naive baselines are deterministic; we evaluate them through the same
+    # pipeline as fine-tuned models (mode=finetuned) so we mark them
+    # fine_tunable rather than zero_shot_capable to match how the runs are
+    # recorded.  Conceptually they have no learnable parameters either way.
+    "naive_baseline/Naive": {
+        "class": "naive",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": False,
+        "architecture_summary": (
+            "Last-observation-carried-forward. Deterministic; no learnable parameters."
+        ),
+    },
+    "naive_baseline/Average": {
+        "class": "naive",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": False,
+        "architecture_summary": (
+            "Mean of the context window. Deterministic; no learnable parameters."
+        ),
+    },
+    # ---- Statistical ----
+    "statistical/AutoARIMA": {
+        "class": "statistical",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Box-Jenkins ARIMA with automated (p,d,q) order selection per series; "
+            "Gaussian predictive distribution."
+        ),
+    },
+    "statistical/Theta": {
+        "class": "statistical",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": False,
+        "architecture_summary": (
+            "Theta decomposition: drift line + simple exponential smoothing of "
+            "deseasonalised series. Point forecasts only."
+        ),
+    },
+    "statistical/NPTS": {
+        "class": "statistical",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Non-Parametric Time Series: empirical resampling of historical values "
+            "with kernel-weighted recency."
+        ),
+    },
+    # ---- Deep learning (trained from scratch / on our data) ----
+    "deepar": {
+        "class": "deep_learning",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": False,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Autoregressive LSTM emitting parametric (Student-t/Gaussian) "
+            "likelihood per step. AutoGluon only exposes known (future-available) "
+            "covariates for DeepAR; past-only covariates like IOB/COB cannot be "
+            "used without data leakage."
+        ),
+    },
+    "tft": {
+        "class": "deep_learning",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Temporal Fusion Transformer: variable-selection networks + LSTM "
+            "encoder/decoder + multi-head interpretable attention + quantile head."
+        ),
+    },
+    "patchtst": {
+        "class": "deep_learning",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": False,
+        "architecture_summary": (
+            "Patch-tokenised transformer encoder, channel-independent. "
+            "Point/quantile forecasts; no native covariate support."
+        ),
+    },
+    "tide": {
+        "class": "deep_learning",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": False,
+        "probabilistic": False,
+        "architecture_summary": (
+            "Time-series Dense Encoder: pure MLP encoder-decoder with residual "
+            "connections; no attention. Point forecasts. AutoGluon only exposes "
+            "known (future-available) covariates for TiDE; past-only covariates "
+            "like IOB/COB cannot be used without data leakage."
+        ),
+    },
+    "timegrad": {
+        "class": "deep_learning",
+        "zero_shot_capable": False,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Autoregressive denoising-diffusion RNN: LSTM hidden state conditions "
+            "a per-step DDPM that samples next observation. Uses the pts library "
+            "directly (not AutoGluon); only BG context is consumed — no covariate "
+            "inputs are wired in."
+        ),
+    },
+    # ---- Foundation (pre-trained) ----
+    "chronos2": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": True,
+        "architecture_summary": (
+            "T5 encoder-decoder over quantised value tokens (Chronos-2). "
+            "Native past + static covariates; quantile sampling."
+        ),
+    },
+    "moirai": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Masked encoder transformer with patch embeddings and multi-patch-size "
+            "attention; any-variate forecasting."
+        ),
+    },
+    "toto": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Datadog Toto: decoder-only transformer foundation model with "
+            "proprietary tokeniser, trained on observability time-series."
+        ),
+    },
+    "timesfm": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": True,
+        "architecture_summary": (
+            "Google TimesFM: decoder-only transformer with input/output patching; "
+            "univariate; quantile head."
+        ),
+    },
+    "ttm": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": False,
+        "architecture_summary": (
+            "TinyTimeMixer (IBM): mixer-style channel/patch MLPs (no attention); "
+            "very small (~1M params). Point forecasts."
+        ),
+    },
+    "sundial": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": False,
+        "supports_past_covariates": False,
+        "univariate_only": True,
+        "probabilistic": True,
+        "architecture_summary": (
+            "THUML Sundial: generative diffusion-based transformer foundation model "
+            "(ICML 2025). Draws sample paths via autoregressive generation; "
+            "quantiles derived from samples. Used zero-shot only in this study."
+        ),
+    },
+    "moment": {
+        "class": "foundation",
+        "zero_shot_capable": True,
+        "fine_tunable": True,
+        "supports_past_covariates": True,
+        "univariate_only": False,
+        "probabilistic": False,
+        "architecture_summary": (
+            "MOMENT (CMU): masked-reconstruction transformer foundation model "
+            "with patch embeddings; channel-independent variant supports past "
+            "covariates via concatenation. Point forecasts."
+        ),
+    },
+}
+
+
+def model_supports_past_covariates(model_name: str) -> bool:
+    """Return True if *model_name* can consume past covariate columns.
+
+    Looks up ``MODEL_PROPERTIES`` by exact key first, then by the base model
+    name (stripping any ``/variant`` suffix).  Returns ``False`` for unknown
+    models so that unrecognised names are treated conservatively.
+    """
+    if model_name in MODEL_PROPERTIES:
+        return MODEL_PROPERTIES[model_name]["supports_past_covariates"]
+    base = model_name.split("/")[0]
+    if base in MODEL_PROPERTIES:
+        return MODEL_PROPERTIES[base]["supports_past_covariates"]
+    return False
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+def load_summary(paths: Sequence[str | Path]) -> pd.DataFrame:
+    """Load + concat one or more summary.csv files, recording their source."""
+    frames = []
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            log.warning("Summary file not found: %s", path)
+            continue
+        df = pd.read_csv(path)
+        df["_source_summary"] = str(path)
+        frames.append(df)
+    if not frames:
+        raise FileNotFoundError(f"None of the provided summary files exist: {paths}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def dedupe(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop duplicate evals on (model, dataset, mode, checkpoint, ctx_fh).
+
+    Keeps the row with the latest timestamp.
+    """
+    out = df.copy()
+    out["timestamp"] = pd.to_datetime(out["timestamp"], errors="coerce")
+    out = out.sort_values("timestamp")
+    keys = ["model", "dataset", "mode", "checkpoint", "ctx_fh"]
+    # `checkpoint` is NaN for zero-shot; fillna so groupby keeps zero-shots
+    # collapsed too.
+    for k in keys:
+        if k in out.columns:
+            out[k] = out[k].fillna("")
+    out = out.drop_duplicates(subset=keys, keep="last")
+    return out.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Covariate-bucket attachment
+# ---------------------------------------------------------------------------
+
+
+def read_covariate_cols(run_path: str | Path) -> list[str] | None:
+    """Read `cli_args.covariate_cols` from a run's experiment_config.json."""
+    cfg_path = Path(run_path) / "experiment_config.json"
+    if not cfg_path.exists():
+        return None
+    try:
+        with cfg_path.open() as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Could not read %s: %s", cfg_path, exc)
+        return None
+    cli = cfg.get("cli_args", {}) or {}
+    cols = cli.get("covariate_cols")
+    if cols is None:
+        # Fall back to model_config.covariate_cols (populated when covariates
+        # are specified in the model YAML rather than as CLI args).
+        model_cfg = cfg.get("model_config", {}) or {}
+        cols = model_cfg.get("covariate_cols")
+    if cols is None:
+        return []
+    if isinstance(cols, list):
+        return [str(c) for c in cols]
+    return []
+
+
+# Carb-related covariates that count as the COB-family signal.
+_CARB_COVARIATES: frozenset[str] = frozenset({"cob", "carb_availability", "carbs"})
+# Insulin-related (beyond plain IOB) covariates that count as IOB-family signal.
+_INSULIN_COVARIATES: frozenset[str] = frozenset({"iob", "ia", "insulin_availability"})
+
+# Bucket hierarchy: each bucket implies all buckets that are subsets of it.
+# bg_only and zero_shot are always universal so they are NOT listed here.
+_BUCKET_IMPLIES: dict[str, frozenset[str]] = {
+    "iob_cob": frozenset({"iob_cob", "iob"}),
+    "iob": frozenset({"iob"}),
+}
+
+
+def _expand_valid_buckets(native: frozenset[str]) -> frozenset[str]:
+    """Expand a dataset's declared covariate capabilities via the bucket hierarchy.
+
+    The hierarchy is: iob_cob ⊇ iob ⊇ bg_only.
+    bg_only and zero_shot are always universal and are handled separately;
+    they do not appear in the returned set.
+    """
+    expanded: set[str] = set()
+    for b in native:
+        expanded |= _BUCKET_IMPLIES.get(b, frozenset({b}))
+    return frozenset(expanded)
+
+
+def bucket_from_covariates(mode: str, cov_cols: Iterable[str] | None) -> str:
+    """Map (mode, covariate_cols) to one of COV_BUCKETS.
+
+    ``mode`` should be the normalised string produced by the summarizer
+    (hyphens stripped, lower-cased), e.g. ``"zeroshot"`` or ``"finetuned"``.
+
+    Buckets:
+        zero_shot -- model run in zero-shot mode
+        iob_cob   -- both insulin (IOB / insulin_availability) and carb signals present
+        iob       -- insulin signal only: any of iob, ia, insulin_availability
+        bg_only   -- no non-BG covariates (cob-only configurations are not valid
+                     and are treated as bg_only with a warning)
+    """
+    if mode == "zeroshot":
+        return "zero_shot"
+    cset = {c.lower() for c in (cov_cols or [])}
+    # Drop time-feature names that aren't clinical BG covariates
+    cset -= {"hour_sin", "hour_cos", "minute_sin", "minute_cos", "day_sin", "day_cos"}
+    if not cset:
+        return "bg_only"
+    has_carb = bool(cset & _CARB_COVARIATES)
+    has_insulin = bool(cset & _INSULIN_COVARIATES)
+    if has_carb and has_insulin:
+        return "iob_cob"
+    if has_insulin:
+        return "iob"
+    if has_carb:
+        # COB-only is not a valid configuration; flag and fall back to bg_only
+        log.warning(
+            "Carb-only covariate set %s — no insulin covariates present. "
+            "COB-only is not a valid bucket; bucketing as bg_only.",
+            sorted(cset),
+        )
+        return "bg_only"
+    # Unknown covariate set: treat as BG-only and warn
+    log.warning("Unrecognised covariate set %s — bucketing as bg_only", sorted(cset))
+    return "bg_only"
+
+
+def attach_covariate_bucket(df: pd.DataFrame) -> pd.DataFrame:
+    """Add `cov_bucket` and `cov_variant` columns to a summary DataFrame.
+
+    Reads each run's `experiment_config.json` (cached in-process by run_path).
+    """
+    cache: dict[str, list[str] | None] = {}
+    buckets: list[str] = []
+    variants: list[str] = []
+    for _, row in df.iterrows():
+        run_path = str(row.get("run_path", ""))
+        mode = str(row.get("mode", ""))
+        if run_path not in cache:
+            cache[run_path] = read_covariate_cols(run_path)
+        cov_cols = cache[run_path]
+        buckets.append(bucket_from_covariates(mode, cov_cols))
+        variants.append(",".join(sorted(cov_cols)) if cov_cols else "")
+    out = df.copy()
+    out["cov_bucket"] = buckets
+    out["cov_variant"] = variants
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Best-run selection + pivoting
+# ---------------------------------------------------------------------------
+
+
+def pick_best(
+    df: pd.DataFrame,
+    group_cols: Sequence[str] = ("model", "dataset", "cov_bucket"),
+) -> pd.DataFrame:
+    """Pick one row per group: lowest RMSE, tie-break on WQL then latest ts."""
+    out = df.copy()
+    out["rmse"] = pd.to_numeric(out["rmse"], errors="coerce")
+    out["wql"] = pd.to_numeric(out["wql"], errors="coerce")
+    out = out.dropna(subset=["rmse"])
+    # Stable sort: latest timestamp first, then wql, then rmse, so groupby.first
+    # yields lowest rmse, lowest wql, latest ts within ties.
+    out["timestamp"] = pd.to_datetime(out["timestamp"], errors="coerce")
+    out = out.sort_values(
+        ["rmse", "wql", "timestamp"],
+        ascending=[True, True, False],
+        na_position="last",
+    )
+    return out.groupby(list(group_cols), as_index=False).first()
+
+
+def _model_class(model: str) -> str:
+    props = MODEL_PROPERTIES.get(model)
+    if props:
+        return props["class"]
+    # Fallback: try parent (e.g. statistical/Foo -> statistical)
+    parent = model.split("/", 1)[0]
+    parent_props = MODEL_PROPERTIES.get(parent)
+    if parent_props:
+        return parent_props["class"]
+    return "deep_learning"
+
+
+def _model_sort_key(model: str) -> tuple[int, str]:
+    cls = _model_class(model)
+    cls_idx = MODEL_CLASS_ORDER.index(cls) if cls in MODEL_CLASS_ORDER else 99
+    return (cls_idx, model)
+
+
+def pivot_wide(
+    df_best: pd.DataFrame,
+    datasets: Sequence[str] = DATASETS,
+    metrics: Sequence[str] = DEFAULT_METRICS,
+) -> pd.DataFrame:
+    """Pivot best-runs DF to wide form.
+
+    Index : MultiIndex (model_class, model, cov_bucket)
+    Cols  : MultiIndex (dataset, metric)
+    """
+    rows: dict[tuple[str, str, str], dict[tuple[str, str], float]] = {}
+    for _, r in df_best.iterrows():
+        model = str(r["model"])
+        cls = _model_class(model)
+        bucket = str(r["cov_bucket"])
+        ds = str(r["dataset"])
+        if ds not in datasets or bucket not in COV_BUCKETS:
+            continue
+        key = (cls, model, bucket)
+        rows.setdefault(key, {})
+        for m in metrics:
+            val = r.get(m)
+            try:
+                rows[key][(ds, m)] = float(val) if pd.notna(val) else float("nan")
+            except (TypeError, ValueError):
+                rows[key][(ds, m)] = float("nan")
+
+    if not rows:
+        return pd.DataFrame()
+
+    col_index = pd.MultiIndex.from_product(
+        [list(datasets), list(metrics)], names=["dataset", "metric"]
+    )
+    sorted_keys = sorted(
+        rows.keys(),
+        key=lambda k: (
+            MODEL_CLASS_ORDER.index(k[0]) if k[0] in MODEL_CLASS_ORDER else 99,
+            k[1],  # model
+            COV_BUCKETS.index(k[2]) if k[2] in COV_BUCKETS else 99,
+        ),
+    )
+    row_index = pd.MultiIndex.from_tuples(
+        sorted_keys, names=["model_class", "model", "cov_bucket"]
+    )
+    data = [[rows[k].get(c, float("nan")) for c in col_index] for k in sorted_keys]
+    return pd.DataFrame(data, index=row_index, columns=col_index)
+
+
+# ---------------------------------------------------------------------------
+# Model property matrix + missing-combinations
+# ---------------------------------------------------------------------------
+
+
+def build_model_properties_df() -> pd.DataFrame:
+    rows = []
+    for model, props in MODEL_PROPERTIES.items():
+        rows.append({"model": model, **props})
+    df = pd.DataFrame(rows)
+    df["_class_idx"] = df["class"].map(
+        lambda c: MODEL_CLASS_ORDER.index(c) if c in MODEL_CLASS_ORDER else 99
+    )
+    df = df.sort_values(["_class_idx", "model"]).drop(columns=["_class_idx"])
+    return df.reset_index(drop=True)
+
+
+def expected_combinations() -> set[tuple[str, str, str]]:
+    """Set of (model, dataset, cov_bucket) that *should* exist per properties.
+
+    Dataset-aware: covariate buckets beyond bg_only are only expected where the
+    dataset actually has those covariates (see VALID_COVARIATE_BUCKETS_BY_DATASET).
+    The bucket hierarchy (iob_cob ⊇ iob) is applied via _expand_valid_buckets so
+    that, e.g., a dataset declaring {iob_cob} also expects iob runs.
+    """
+    expected: set[tuple[str, str, str]] = set()
+    for model, props in MODEL_PROPERTIES.items():
+        base_buckets: list[str] = []
+        if props["zero_shot_capable"]:
+            base_buckets.append("zero_shot")
+        if props["fine_tunable"]:
+            base_buckets.append("bg_only")
+        for ds in DATASETS:
+            for b in base_buckets:
+                expected.add((model, ds, b))
+            if props["fine_tunable"] and props["supports_past_covariates"]:
+                valid_cov = _expand_valid_buckets(
+                    VALID_COVARIATE_BUCKETS_BY_DATASET.get(ds, frozenset())
+                )
+                for b in valid_cov:
+                    expected.add((model, ds, b))
+    return expected
+
+
+def find_missing(df_best: pd.DataFrame) -> pd.DataFrame:
+    have = set(
+        zip(
+            df_best["model"].astype(str),
+            df_best["dataset"].astype(str),
+            df_best["cov_bucket"].astype(str),
+        )
+    )
+    missing = expected_combinations() - have
+    rows = [
+        {
+            "model": m,
+            "dataset": d,
+            "cov_bucket": b,
+            "model_class": _model_class(m),
+        }
+        for (m, d, b) in sorted(
+            missing, key=lambda x: (_model_sort_key(x[0]), x[1], x[2])
+        )
+    ]
+    return pd.DataFrame(rows)
+
+
+def find_misplaced(df_best: pd.DataFrame) -> pd.DataFrame:
+    """Find runs recorded in a covariate bucket that is invalid for their dataset.
+
+    A run is *misplaced* when its cov_bucket is not in {zero_shot, bg_only} AND
+    not in the hierarchy-expanded valid set for the run's dataset.  The bucket
+    hierarchy (iob_cob ⊇ iob) is respected via _expand_valid_buckets, so a
+    dataset that has iob_cob data is also considered valid for iob runs.
+    """
+    rows = []
+    universal_buckets = frozenset({"zero_shot", "bg_only"})
+    for _, r in df_best.iterrows():
+        bucket = str(r["cov_bucket"])
+        ds = str(r["dataset"])
+        if bucket in universal_buckets:
+            continue
+        valid = _expand_valid_buckets(
+            VALID_COVARIATE_BUCKETS_BY_DATASET.get(ds, frozenset())
+        )
+        if bucket not in valid:
+            rows.append(
+                {
+                    "model": r["model"],
+                    "dataset": ds,
+                    "cov_bucket": bucket,
+                    "cov_variant": r.get("cov_variant", ""),
+                    "model_class": _model_class(str(r["model"])),
+                    "run_path": r.get("run_path", ""),
+                }
+            )
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "model",
+                "dataset",
+                "cov_bucket",
+                "cov_variant",
+                "model_class",
+                "run_path",
+            ]
+        )
+    return (
+        pd.DataFrame(rows)
+        .sort_values(["model_class", "model", "dataset", "cov_bucket"])
+        .reset_index(drop=True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def build_grand_summary(
+    summary_paths: Sequence[str | Path],
+    datasets: Sequence[str] = DATASETS,
+    metrics: Sequence[str] = DEFAULT_METRICS,
+    ctx_filter: int | None = None,
+    forecast_filter: int | None = 96,
+) -> dict[str, pd.DataFrame]:
+    """End-to-end pipeline. Returns a dict of named DataFrames."""
+    raw = load_summary(summary_paths)
+    if forecast_filter is not None and "forecast_length" in raw.columns:
+        raw = raw[raw["forecast_length"] == forecast_filter]
+    if ctx_filter is not None and "ctx_fh" in raw.columns:
+        raw = raw[raw["ctx_fh"].str.startswith(f"{ctx_filter}ctx_")]
+    # Only include models registered in MODEL_PROPERTIES; unrecognised names
+    # indicate deprecated or misconfigured runs (e.g. AutoARIMA+IOB which
+    # silently ignores IOB due to AutoGluon's known_covariates_names limitation).
+    raw = raw[raw["model"].isin(MODEL_PROPERTIES)]
+    deduped = dedupe(raw)
+    bucketed = attach_covariate_bucket(deduped)
+    best = pick_best(bucketed)
+    wide = pivot_wide(best, datasets=datasets, metrics=metrics)
+    missing = find_missing(best)
+    misplaced = find_misplaced(best)
+    properties = build_model_properties_df()
+    return {
+        "results_wide": wide,
+        "best_runs_long": best,
+        "missing_combinations": missing,
+        "misplaced_combinations": misplaced,
+        "model_properties": properties,
+        "all_runs_bucketed": bucketed,
+    }

--- a/src/experiments/nocturnal/grand_summary_split.py
+++ b/src/experiments/nocturnal/grand_summary_split.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Best-run breakdown across the patient/temporal holdout split.
+
+This module reuses the leaderboard plumbing in
+``src.experiments.nocturnal.grand_summary`` to identify the best
+(model × dataset × cov_bucket) run for a given holdout ablation, then
+re-aggregates the per-episode metrics in each best run separately for the
+patient-holdout vs temporal-holdout subsets.
+
+It does **not** mutate ``summary.csv`` or modify ``grand_summary.py``.
+
+Aggregation rules (matching ``src/evaluation/nocturnal.py``):
+  * ``rmse``                – sqrt(mean(squared_error)) over the split's
+                              (episode, step) pairs, recomputed from the
+                              raw arrays in ``forecasts.npz``.
+  * ``wql``, ``brier_3_9``, ``discontinuity``, ``coverage_*``,
+    ``sharpness_*``, ``dilate_*``, ``shape_*``, ``temporal_*`` –
+                              nanmean of the per-episode values in the split.
+  * ``n_episodes``           – row count.
+  * ``n_episodes_with_hypo`` – count of episodes whose actual BG dipped below
+                              ``HYPO_THRESHOLD_MMOL`` at any forecast step.
+  * ``n_patients``           – distinct patient_id count.
+
+``mace`` is omitted because it requires the per-step quantile arrays
+across all episodes in the split; it is only available at the overall level.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from src.experiments.nocturnal.grand_summary import (
+    DATASETS,
+    MODEL_PROPERTIES,
+    attach_covariate_bucket,
+    dedupe,
+    load_summary,
+    pick_best,
+)
+from src.experiments.nocturnal.holdout_split_analysis import (
+    HYPO_THRESHOLD_MMOL,
+    SPLIT_PATIENT,
+    SPLIT_TEMPORAL,
+    load_run_episode_classification,
+)
+
+log = logging.getLogger(__name__)
+
+# Per-episode metric columns to average within a split.
+_MEAN_METRICS_REQUIRED: tuple[str, ...] = ("discontinuity",)
+_MEAN_METRICS_OPTIONAL: tuple[str, ...] = (
+    "wql",
+    "brier",
+    "coverage_50",
+    "coverage_80",
+    "coverage_90",
+    "coverage_95",
+    "sharpness_50",
+    "sharpness_80",
+    "sharpness_90",
+    "sharpness_95",
+    "dilate_g0001",
+    "shape_g0001",
+    "temporal_g0001",
+    "dilate_g001",
+    "shape_g001",
+    "temporal_g001",
+    "dilate_g01",
+    "shape_g01",
+    "temporal_g01",
+)
+
+_SPLITS: tuple[str, ...] = (SPLIT_PATIENT, SPLIT_TEMPORAL)
+
+
+# ---------------------------------------------------------------------------
+# Filtering by config_dir
+# ---------------------------------------------------------------------------
+
+
+def _read_config_dir(run_path: str) -> str | None:
+    cfg_path = Path(run_path) / "experiment_config.json"
+    if not cfg_path.exists():
+        return None
+    try:
+        with cfg_path.open() as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    cli = cfg.get("cli_args", {}) or {}
+    cd = cli.get("config_dir")
+    return str(cd) if cd else None
+
+
+def attach_config_dir(df: pd.DataFrame) -> pd.DataFrame:
+    """Add a ``config_dir`` column derived from each run's experiment config.
+
+    Cached per ``run_path`` to avoid re-reading the same file.
+    """
+    cache: dict[str, str | None] = {}
+    cds: list[str | None] = []
+    for run_path in df["run_path"].astype(str):
+        if run_path not in cache:
+            cache[run_path] = _read_config_dir(run_path)
+        cds.append(cache[run_path])
+    out = df.copy()
+    out["config_dir"] = cds
+    return out
+
+
+def filter_to_config_dir(df: pd.DataFrame, config_dir: str) -> pd.DataFrame:
+    """Keep only rows whose run was launched with ``--config-dir == config_dir``."""
+    if "config_dir" not in df.columns:
+        df = attach_config_dir(df)
+    return df[df["config_dir"] == config_dir].copy()
+
+
+# ---------------------------------------------------------------------------
+# Per-run split aggregation
+# ---------------------------------------------------------------------------
+
+
+def _split_rmse(predictions: np.ndarray, actuals: np.ndarray) -> float:
+    if predictions.size == 0:
+        return float("nan")
+    return float(np.sqrt(np.mean((predictions - actuals) ** 2)))
+
+
+def aggregate_run_by_split(
+    run_path: str | Path,
+    *,
+    model: str,
+    dataset: str,
+    cov_bucket: str,
+    config_dir: str,
+) -> list[dict]:
+    """Return one row per ``split_type`` for the given run."""
+    df = load_run_episode_classification(
+        run_path, config_dir=config_dir, dataset=dataset
+    )
+    rows: list[dict] = []
+    for split in _SPLITS:
+        sub = df[df["split_type"] == split]
+        if sub.empty:
+            row: dict = {
+                "model": model,
+                "dataset": dataset,
+                "cov_bucket": cov_bucket,
+                "split_type": split,
+                "n_patients": 0,
+                "n_episodes": 0,
+                "n_episodes_with_hypo": 0,
+                "hypo_rate": float("nan"),
+                "rmse": float("nan"),
+                "run_path": str(run_path),
+            }
+            for col in _MEAN_METRICS_REQUIRED + _MEAN_METRICS_OPTIONAL:
+                row[col if col != "brier" else "brier_3_9"] = float("nan")
+            rows.append(row)
+            continue
+
+        preds = np.stack(sub["predictions"].to_numpy())
+        actuals = np.stack(sub["actuals"].to_numpy())
+        n_eps = int(len(sub))
+        n_hypo = int(sub["has_hypo"].sum())
+        row = {
+            "model": model,
+            "dataset": dataset,
+            "cov_bucket": cov_bucket,
+            "split_type": split,
+            "n_patients": int(sub["patient_id"].nunique()),
+            "n_episodes": n_eps,
+            "n_episodes_with_hypo": n_hypo,
+            "hypo_rate": (n_hypo / n_eps) if n_eps else float("nan"),
+            "rmse": _split_rmse(preds, actuals),
+            "run_path": str(run_path),
+        }
+        for col in _MEAN_METRICS_REQUIRED:
+            row[col] = float(sub[col].mean(skipna=True)) if col in sub else float("nan")
+        for col in _MEAN_METRICS_OPTIONAL:
+            out_col = "brier_3_9" if col == "brier" else col
+            if col in sub.columns:
+                vals = pd.to_numeric(sub[col], errors="coerce")
+                row[out_col] = (
+                    float(vals.mean(skipna=True))
+                    if vals.notna().any()
+                    else float("nan")
+                )
+            else:
+                row[out_col] = float("nan")
+        rows.append(row)
+    return rows
+
+
+def _model_class(model: str) -> str:
+    props = MODEL_PROPERTIES.get(model)
+    if props:
+        return str(props["class"])
+    parent = model.split("/", 1)[0]
+    parent_props = MODEL_PROPERTIES.get(parent)
+    if parent_props:
+        return str(parent_props["class"])
+    return "deep_learning"
+
+
+# ---------------------------------------------------------------------------
+# Top-level pipeline
+# ---------------------------------------------------------------------------
+
+
+def build_best_split_breakdown(
+    summary_paths: Sequence[str | Path],
+    config_dir: str,
+    *,
+    datasets: Sequence[str] = DATASETS,
+    ctx_filter: int | None = None,
+    forecast_filter: int | None = 96,
+) -> pd.DataFrame:
+    """Build the long-form best-runs split breakdown for one holdout ablation.
+
+    Parameters mirror :func:`grand_summary.build_grand_summary`.
+
+    Returns a DataFrame with one row per
+    ``(model, dataset, cov_bucket, split_type)``.
+    """
+    raw = load_summary(summary_paths)
+    if forecast_filter is not None and "forecast_length" in raw.columns:
+        raw = raw[raw["forecast_length"] == forecast_filter]
+    if ctx_filter is not None and "context_length" in raw.columns:
+        raw = raw[raw["context_length"] == ctx_filter]
+    raw = raw[raw["model"].isin(MODEL_PROPERTIES)]
+    raw = raw[raw["dataset"].isin(list(datasets))]
+    raw = attach_config_dir(raw)
+    raw = raw[raw["config_dir"] == config_dir]
+    if raw.empty:
+        log.warning(
+            "No runs match config_dir=%s after filtering; returning empty frame.",
+            config_dir,
+        )
+        return pd.DataFrame()
+    deduped = dedupe(raw)
+    bucketed = attach_covariate_bucket(deduped)
+
+    # Build a ranked list of all candidates per group (same sort as pick_best).
+    # We walk down the ranking until we find a run that has episodes.parquet,
+    # so that old runs missing the file don't silently drop the whole group.
+    # GROUP_COLS = ["model", "dataset", "cov_bucket"]
+    ranked = (
+        pick_best.__wrapped__(bucketed)
+        if hasattr(pick_best, "__wrapped__")
+        else bucketed.copy()
+    )
+    ranked["rmse"] = pd.to_numeric(ranked["rmse"], errors="coerce")
+    ranked["wql"] = pd.to_numeric(ranked["wql"], errors="coerce")
+    ranked["timestamp"] = pd.to_datetime(ranked["timestamp"], errors="coerce")
+    ranked = ranked.dropna(subset=["rmse"]).sort_values(
+        ["rmse", "wql", "timestamp"], ascending=[True, True, False], na_position="last"
+    )
+    candidates: dict[tuple, list] = {}
+    for _, r in ranked.iterrows():
+        key = (str(r["model"]), str(r["dataset"]), str(r["cov_bucket"]))
+        candidates.setdefault(key, []).append(r)
+
+    rows: list[dict] = []
+    for key, cands in candidates.items():
+        model_name, dataset_name, cov_bucket_name = key
+        split_rows = None
+        for r in cands:
+            run_path = str(r["run_path"])
+            try:
+                split_rows = aggregate_run_by_split(
+                    run_path,
+                    model=model_name,
+                    dataset=dataset_name,
+                    cov_bucket=cov_bucket_name,
+                    config_dir=config_dir,
+                )
+                break  # success — use this run
+            except (FileNotFoundError, ValueError) as exc:
+                log.warning(
+                    "Skipping %s (falling back to next-best): %s", run_path, exc
+                )
+        if split_rows is None:
+            log.warning(
+                "No usable run found for (%s, %s, %s) — all candidates missing episodes.parquet",
+                model_name,
+                dataset_name,
+                cov_bucket_name,
+            )
+            continue
+        # r is the last successfully used candidate row
+        for sr in split_rows:
+            sr["model_class"] = _model_class(sr["model"])
+            sr["context_length"] = r.get("context_length")
+            sr["forecast_length"] = r.get("forecast_length")
+            sr["overall_rmse"] = (
+                float(r.get("rmse")) if pd.notna(r.get("rmse")) else float("nan")
+            )
+            sr["overall_wql"] = (
+                float(r.get("wql")) if pd.notna(r.get("wql")) else float("nan")
+            )
+            rows.append(sr)
+    out = pd.DataFrame(rows)
+    if not out.empty:
+        out = out.sort_values(
+            ["model_class", "model", "dataset", "cov_bucket", "split_type"]
+        ).reset_index(drop=True)
+        # Lead with the identifier/grouping columns so downstream sorting
+        # and pivoting is straightforward.
+        lead = [
+            "model_class",
+            "model",
+            "dataset",
+            "cov_bucket",
+            "split_type",
+            "n_patients",
+            "n_episodes",
+            "n_episodes_with_hypo",
+            "hypo_rate",
+            "rmse",
+        ]
+        rest = [c for c in out.columns if c not in lead]
+        out = out[[c for c in lead if c in out.columns] + rest]
+    return out
+
+
+__all__ = [
+    "HYPO_THRESHOLD_MMOL",
+    "aggregate_run_by_split",
+    "attach_config_dir",
+    "build_best_split_breakdown",
+    "filter_to_config_dir",
+]

--- a/src/experiments/nocturnal/holdout_split_analysis.py
+++ b/src/experiments/nocturnal/holdout_split_analysis.py
@@ -1,0 +1,432 @@
+# Copyright (c) 2025 Blood-Glucose-Control
+# Licensed under Custom Research License (see LICENSE file)
+
+"""Helpers for splitting nocturnal evaluation episodes into the
+patient-holdout vs temporal-holdout subsets used by hybrid data ablations.
+
+A run's three-tier outputs (``episodes.parquet`` + ``forecasts.npz`` +
+``experiment_config.json``) carry everything needed to label each midnight
+episode by *which* type of holdout it came from:
+
+  * The run's ``experiment_config.json::cli_args.config_dir`` points to the
+    holdout YAML directory (e.g. ``configs/data/holdout_10pct``).
+  * That directory contains ``<dataset>.yaml`` whose
+    ``patient_config.holdout_patients`` lists the entirely-held-out patients.
+  * Any episode whose ``patient_id`` is in that list belongs to the
+    *patient* split; everything else is *temporal*.
+
+The actuals array in ``forecasts.npz`` is row-aligned with
+``episodes.parquet`` (both built from ``all_episode_results`` in
+``src/evaluation/nocturnal.py``), so we can also flag any episode containing
+a true BG reading below the hypoglycemia threshold (3.9 mmol/L).
+
+Module: experiments.nocturnal.holdout_split_analysis
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from src.data.versioning.holdout_config import HoldoutConfig
+
+log = logging.getLogger(__name__)
+
+# Matches HYPO_THRESHOLD_MMOL in src/evaluation/nocturnal.py.
+HYPO_THRESHOLD_MMOL: float = 3.9
+
+SPLIT_PATIENT: str = "patient"
+SPLIT_TEMPORAL: str = "temporal"
+
+
+# ---------------------------------------------------------------------------
+# Holdout YAML helpers
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=None)
+def load_holdout_patient_set(config_dir: str | Path, dataset: str) -> frozenset[str]:
+    """Return the set of patient IDs held out *entirely* for ``dataset``.
+
+    Reads ``<config_dir>/<dataset>.yaml`` and pulls
+    ``patient_config.holdout_patients``. Cached per ``(config_dir, dataset)``.
+    """
+    yaml_path = Path(config_dir) / f"{dataset}.yaml"
+    cfg = HoldoutConfig.load(yaml_path)
+    if cfg.patient_config is None or not cfg.patient_config.holdout_patients:
+        log.warning(
+            "%s has no patient_config.holdout_patients — all episodes will "
+            "be classified as temporal-holdout.",
+            yaml_path,
+        )
+        return frozenset()
+    return frozenset(str(p) for p in cfg.patient_config.holdout_patients)
+
+
+# ---------------------------------------------------------------------------
+# Run loading
+# ---------------------------------------------------------------------------
+
+
+def read_run_config_dir(run_path: str | Path) -> str | None:
+    """Return the holdout ``config_dir`` recorded in a run's experiment config.
+
+    None if the file is missing or the field is absent.
+    """
+    cfg_path = Path(run_path) / "experiment_config.json"
+    if not cfg_path.exists():
+        return None
+    try:
+        with cfg_path.open() as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Could not read %s: %s", cfg_path, exc)
+        return None
+    cli = cfg.get("cli_args", {}) or {}
+    cd = cli.get("config_dir")
+    return str(cd) if cd else None
+
+
+def read_run_dataset(run_path: str | Path) -> str | None:
+    """Return the dataset name recorded in a run's experiment config."""
+    cfg_path = Path(run_path) / "experiment_config.json"
+    if not cfg_path.exists():
+        return None
+    try:
+        with cfg_path.open() as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Could not read %s: %s", cfg_path, exc)
+        return None
+    cli = cfg.get("cli_args", {}) or {}
+    ds = cli.get("dataset")
+    return str(ds) if ds else None
+
+
+# ---------------------------------------------------------------------------
+# Episode classification
+# ---------------------------------------------------------------------------
+
+
+def classify_episodes(
+    patient_ids: Iterable[str],
+    holdout_patient_set: Iterable[str],
+) -> np.ndarray:
+    """Return an array of ``"patient"``/``"temporal"`` per episode."""
+    holdout = frozenset(str(p) for p in holdout_patient_set)
+    return np.array(
+        [SPLIT_PATIENT if str(p) in holdout else SPLIT_TEMPORAL for p in patient_ids],
+        dtype=object,
+    )
+
+
+def episode_has_hypo(
+    actuals: np.ndarray,
+    threshold: float = HYPO_THRESHOLD_MMOL,
+) -> np.ndarray:
+    """Boolean array, one per episode, True iff any forecast-window step
+    has an actual BG reading strictly below ``threshold``.
+    """
+    if actuals.ndim != 2:
+        raise ValueError(
+            f"Expected actuals of shape (n_episodes, fh); got {actuals.shape}"
+        )
+    return actuals.min(axis=1) < threshold
+
+
+# ---------------------------------------------------------------------------
+# Per-run join
+# ---------------------------------------------------------------------------
+
+
+def load_run_episode_classification(
+    run_path: str | Path,
+    config_dir: str | Path | None = None,
+    dataset: str | None = None,
+) -> pd.DataFrame:
+    """Load a run's per-episode metrics, classified by holdout split.
+
+    Returns the contents of ``episodes.parquet`` augmented with:
+
+      * ``split_type``  – ``"patient"`` or ``"temporal"``
+      * ``has_hypo``    – True iff any actual BG step in the forecast window
+                          is below ``HYPO_THRESHOLD_MMOL``
+      * ``actual_min``  – the minimum actual BG in the forecast window
+      * ``predictions`` – per-episode point forecast array (object dtype)
+      * ``actuals``     – per-episode actuals array (object dtype)
+
+    ``config_dir`` and ``dataset`` default to the values recorded in the
+    run's ``experiment_config.json``.
+    """
+    run_path = Path(run_path)
+    parquet_path = run_path / "episodes.parquet"
+    npz_path = run_path / "forecasts.npz"
+    if not parquet_path.exists():
+        raise FileNotFoundError(parquet_path)
+    if not npz_path.exists():
+        raise FileNotFoundError(npz_path)
+
+    df = pd.read_parquet(parquet_path)
+
+    if config_dir is None:
+        config_dir = read_run_config_dir(run_path)
+        if config_dir is None:
+            raise ValueError(
+                f"{run_path} has no cli_args.config_dir; pass config_dir explicitly"
+            )
+    if dataset is None:
+        dataset = read_run_dataset(run_path)
+        if dataset is None:
+            raise ValueError(
+                f"{run_path} has no cli_args.dataset; pass dataset explicitly"
+            )
+
+    holdout_patients = load_holdout_patient_set(config_dir, dataset)
+
+    with np.load(npz_path, allow_pickle=False) as npz:
+        actuals = np.asarray(npz["actuals"])
+        predictions = np.asarray(npz["predictions"])
+        episode_ids = np.asarray(npz["episode_ids"])
+
+    if len(actuals) != len(df):
+        # Row-alignment is enforced by the storage layer (single iteration
+        # over all_episode_results in src/evaluation/nocturnal.py); a
+        # mismatch indicates a corrupted / mixed-source run directory.
+        raise ValueError(
+            f"{run_path}: episodes.parquet has {len(df)} rows but "
+            f"forecasts.npz has {len(actuals)} — files are out of sync."
+        )
+
+    # Defensive: cross-check via reconstructed episode_id (matches the
+    # f"{patient_id}::ep{i:03d}" format used in evaluate_nocturnal_forecasting).
+    # We don't fail on mismatch (anchor ordering across patients is implicit
+    # in the for-loop iteration order) — only the row count is contractual.
+    if len(episode_ids) and "patient_id" in df.columns:
+        # Cheap sanity: every parquet patient_id should be a prefix of the
+        # corresponding episode_id string.
+        prefix_ok = np.array(
+            [
+                str(eid).startswith(f"{pid}::")
+                for eid, pid in zip(episode_ids, df["patient_id"].astype(str))
+            ]
+        )
+        if not prefix_ok.all():
+            n_bad = int((~prefix_ok).sum())
+            log.warning(
+                "%s: %d/%d episodes have parquet.patient_id not matching "
+                "the npz episode_id prefix; alignment may be wrong.",
+                run_path,
+                n_bad,
+                len(prefix_ok),
+            )
+
+    df = df.copy()
+    df["split_type"] = classify_episodes(df["patient_id"], holdout_patients)
+    df["actual_min"] = actuals.min(axis=1)
+    df["has_hypo"] = df["actual_min"] < HYPO_THRESHOLD_MMOL
+    # Stash arrays for downstream re-aggregation (e.g. split-RMSE).
+    df["predictions"] = list(predictions)
+    df["actuals"] = list(actuals)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Cohort statistics from raw data (incl. training cohort)
+# ---------------------------------------------------------------------------
+
+# Cohort labels for the three-way split:
+#   - patient_holdout : entirely held-out patients (in YAML's holdout_patients)
+#   - temporal_holdout: tail-end of non-holdout patients (the temporal split)
+#   - temporal_train  : everything else (the training data)
+COHORT_PATIENT_HOLDOUT: str = "patient_holdout"
+COHORT_TEMPORAL_HOLDOUT: str = "temporal_holdout"
+COHORT_TEMPORAL_TRAIN: str = "temporal_train"
+
+
+def _patient_episode_stats(
+    patient_df: pd.DataFrame,
+    *,
+    context_length: int,
+    forecast_length: int,
+    target_col: str,
+    interval_mins: int,
+) -> tuple[int, list[float], list[float]]:
+    """Build midnight episodes for a single patient and return
+    ``(n_episodes, list_of_actuals_min, list_of_actuals_flat)``.
+
+    Episodes that don't yield a full ``forecast_length`` window are skipped,
+    matching the filter applied in :func:`evaluate_nocturnal_forecasting`.
+    """
+    # Local import: episode_builders pulls numba which is heavy.
+    from src.evaluation.episode_builders import build_midnight_episodes
+
+    pdf = patient_df.copy()
+    if not isinstance(pdf.index, pd.DatetimeIndex):
+        if "datetime" in pdf.columns:
+            pdf["datetime"] = pd.to_datetime(pdf["datetime"])
+            pdf = pdf.set_index("datetime").sort_index()
+        else:
+            return 0, [], []
+
+    episodes, _ = build_midnight_episodes(
+        pdf,
+        context_length=context_length,
+        forecast_length=forecast_length,
+        target_col=target_col,
+        covariate_cols=None,
+        interval_mins=interval_mins,
+    )
+    mins: list[float] = []
+    flat: list[float] = []
+    n = 0
+    for ep in episodes:
+        tgt = np.asarray(ep["target_bg"])
+        if len(tgt) < forecast_length:
+            continue
+        n += 1
+        mins.append(float(np.min(tgt)))
+        flat.append(float(np.mean(tgt)))  # not used directly; kept for parity
+    # For BG mean/std we want the raw episode arrays, not just the per-episode
+    # mean — return them flattened too.
+    return n, mins, flat
+
+
+def cohort_summary(
+    cohort_df: pd.DataFrame,
+    *,
+    cohort_label: str,
+    dataset: str,
+    context_length: int = 512,
+    forecast_length: int = 96,
+    target_col: str = "bg_mM",
+    interval_mins: int = 5,
+    patient_col: str = "p_num",
+) -> dict:
+    """Compute the per-cohort summary stats requested for the variance check.
+
+    Returns a dict with keys: ``cohort, dataset, n_patients, n_rows,
+    n_episodes, n_episodes_with_hypo, hypo_rate, mean_bg, std_bg, mean_min_bg``.
+
+    BG mean/std are computed on the raw ``target_col`` values across the
+    cohort (one observation per row of ``cohort_df``); ``mean_min_bg`` is
+    the mean of per-episode forecast-window minima, matching how the
+    headline RMSE table is built.
+    """
+    if cohort_df.empty:
+        return {
+            "cohort": cohort_label,
+            "dataset": dataset,
+            "n_patients": 0,
+            "n_rows": 0,
+            "n_episodes": 0,
+            "n_episodes_with_hypo": 0,
+            "hypo_rate": float("nan"),
+            "mean_bg": float("nan"),
+            "std_bg": float("nan"),
+            "mean_min_bg": float("nan"),
+        }
+
+    bg = pd.to_numeric(cohort_df[target_col], errors="coerce")
+    n_rows = int(bg.notna().sum())
+    mean_bg = float(bg.mean(skipna=True))
+    std_bg = float(bg.std(skipna=True))
+    n_patients = int(cohort_df[patient_col].nunique())
+
+    n_episodes_total = 0
+    all_mins: list[float] = []
+    for pid, pdf in cohort_df.groupby(patient_col):
+        n_eps, mins, _ = _patient_episode_stats(
+            pdf,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            target_col=target_col,
+            interval_mins=interval_mins,
+        )
+        n_episodes_total += n_eps
+        all_mins.extend(mins)
+
+    arr = np.asarray(all_mins) if all_mins else np.empty(0)
+    n_hypo = int(np.sum(arr < HYPO_THRESHOLD_MMOL)) if arr.size else 0
+    return {
+        "cohort": cohort_label,
+        "dataset": dataset,
+        "n_patients": n_patients,
+        "n_rows": n_rows,
+        "n_episodes": n_episodes_total,
+        "n_episodes_with_hypo": n_hypo,
+        "hypo_rate": (n_hypo / n_episodes_total) if n_episodes_total else float("nan"),
+        "mean_bg": mean_bg,
+        "std_bg": std_bg,
+        "mean_min_bg": float(arr.mean()) if arr.size else float("nan"),
+    }
+
+
+def build_three_way_cohort_stats(
+    config_dir: str | Path,
+    dataset: str,
+    *,
+    context_length: int = 512,
+    forecast_length: int = 96,
+    target_col: str = "bg_mM",
+    interval_mins: int = 5,
+    patient_col: str = "p_num",
+) -> list[dict]:
+    """Compute cohort stats for ``patient_holdout``, ``temporal_holdout``,
+    and ``temporal_train`` for one dataset.
+
+    Loads the dataset via :class:`DatasetRegistry` using the holdout config at
+    ``<config_dir>/<dataset>.yaml``, then partitions:
+
+      * train_data                          → ``temporal_train``
+      * holdout_data ∩ YAML.holdout_patients → ``patient_holdout``
+      * holdout_data \\ YAML.holdout_patients → ``temporal_holdout``
+    """
+    from src.data.versioning.dataset_registry import DatasetRegistry
+
+    registry = DatasetRegistry(holdout_config_dir=Path(config_dir))
+    train_data, holdout_data = registry.load_dataset_with_split(
+        dataset, patient_col=patient_col
+    )
+    holdout_patients = load_holdout_patient_set(config_dir, dataset)
+
+    h_pat = holdout_data[holdout_data[patient_col].astype(str).isin(holdout_patients)]
+    h_tmp = holdout_data[~holdout_data[patient_col].astype(str).isin(holdout_patients)]
+
+    return [
+        cohort_summary(
+            h_pat,
+            cohort_label=COHORT_PATIENT_HOLDOUT,
+            dataset=dataset,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            target_col=target_col,
+            interval_mins=interval_mins,
+            patient_col=patient_col,
+        ),
+        cohort_summary(
+            h_tmp,
+            cohort_label=COHORT_TEMPORAL_HOLDOUT,
+            dataset=dataset,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            target_col=target_col,
+            interval_mins=interval_mins,
+            patient_col=patient_col,
+        ),
+        cohort_summary(
+            train_data,
+            cohort_label=COHORT_TEMPORAL_TRAIN,
+            dataset=dataset,
+            context_length=context_length,
+            forecast_length=forecast_length,
+            target_col=target_col,
+            interval_mins=interval_mins,
+            patient_col=patient_col,
+        ),
+    ]

--- a/src/experiments/nocturnal/summarize.py
+++ b/src/experiments/nocturnal/summarize.py
@@ -30,6 +30,10 @@ from typing import Any
 
 # Local imports
 from src.experiments.base.experiment import ExperimentSummarizer
+from src.experiments.nocturnal.grand_summary import (
+    bucket_from_covariates,
+    read_covariate_cols,
+)
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +42,12 @@ _RESULTS_FILENAME_OLD = "nocturnal_results.json"
 _CONFIG_FILENAME = "experiment_config.json"  # singular — nocturnal convention
 _CONFIG_FILENAME_ALT = "experiment_configs.json"
 _EXPERIMENT_TYPE = "nocturnal_forecasting"
+
+# Models that have multiple named variants — their model column is enriched
+# with a variant suffix read from training_metadata.json in the checkpoint dir.
+_MULTI_VARIANT_MODELS = frozenset(
+    {"statistical", "naive_baseline", "deepar", "patchtst", "tft"}
+)
 
 
 class NocturnalSummarizer(ExperimentSummarizer):
@@ -124,15 +134,30 @@ class NocturnalSummarizer(ExperimentSummarizer):
         git_commit = _read_git_commit(run_dir)
         checkpoint = data.get("checkpoint") or _read_checkpoint(run_dir)
 
+        # Covariate bucket: prefer value baked into results_summary.json (new
+        # runs); fall back to deriving it from experiment_config.json for old
+        # runs that pre-date the tier_metadata change.
+        cov_bucket = data.get("cov_bucket")
+        if cov_bucket is None:
+            cov_cols = read_covariate_cols(run_dir)
+            cov_bucket = bucket_from_covariates(mode, cov_cols)
+
+        model_str = data.get("model", model)
+        if model_str in _MULTI_VARIANT_MODELS:
+            variant = _read_model_variant(checkpoint)
+            if variant:
+                model_str = f"{model_str}/{variant}"
+
         return {
             "run_id": run_dir.name,
             "run_path": str(run_dir),
             "checkpoint": checkpoint,
             "experiment_type": self.experiment_type,
             "ctx_fh": ctx_fh,
-            "model": data.get("model", model),
+            "model": model_str,
             "dataset": data.get("dataset", ""),
             "mode": mode,
+            "cov_bucket": cov_bucket,
             "timestamp": data.get("timestamp", ""),
             "context_length": cfg.get("context_length"),
             "forecast_length": cfg.get("forecast_length"),
@@ -211,4 +236,39 @@ def _read_checkpoint(run_dir: Path) -> str | None:
                 return checkpoint if checkpoint else None
             except (json.JSONDecodeError, OSError):
                 pass
+    return None
+
+
+def _read_model_variant(checkpoint: str | None) -> str | None:
+    """Read a human-readable variant name from training_metadata.json.
+
+    Looks for ``training_metadata.json`` in the checkpoint directory (or its
+    parent when the checkpoint path points directly to a file such as
+    ``model.pt``).  Returns a string of the form ``"ModelName"`` or
+    ``"ModelName+COV1+COV2"`` when covariate columns are present.
+
+    Returns ``None`` when the metadata file is absent or unreadable.
+    """
+    if not checkpoint:
+        return None
+    cp = Path(checkpoint)
+    # The checkpoint may point to a file (e.g. model.pt) or a directory.
+    candidates = [cp, cp.parent]
+    for candidate in candidates:
+        meta = candidate / "training_metadata.json"
+        if meta.exists():
+            try:
+                with meta.open() as fh:
+                    data = json.load(fh)
+                cfg = data.get("config", {})
+                model_name = cfg.get("model_name", "")
+                if not model_name:
+                    return None
+                cov_cols = cfg.get("covariate_cols") or []
+                if cov_cols:
+                    suffix = "+".join(c.upper() for c in cov_cols)
+                    return f"{model_name}+{suffix}"
+                return model_name
+            except (json.JSONDecodeError, OSError):
+                return None
     return None


### PR DESCRIPTION
## Summary
This PR executes **PR-B** from the `feat/autogluon-baselines` extraction plan by landing reusable nocturnal summary/analysis modules and their companion script entrypoints.

### Included
- New analysis modules under `src/experiments/nocturnal/`:
  - `grand_summary.py`
  - `grand_summary_split.py`
  - `episode_classification.py`
  - `holdout_split_analysis.py`
- Enhancements to summarization path:
  - `src/experiments/nocturnal/summarize.py`
  - `src/experiments/base/experiment.py` (skip reserved `_` directories)
- New script entrypoints under `scripts/analysis/`:
  - `build_grand_summary.py`
  - `build_best_episode_classification.py`
  - `build_best_split_breakdown.py`
  - `build_dataset_cohort_variance.py`
  - `build_dataset_holdout_characteristics.py`
  - `compute_cumrmse_by_timestep.py`
  - `count_episodes_by_gap_policy.py`
  - `plot_bg_histograms_by_split.py`
  - `plot_episode_classification_curves.py`
  - `relocate_768ctx_results.py`

### Explicitly excluded
- Generated artifacts under `results/`
- Experiment CSV snapshots under `experiments/`
- Machine-local rerun manifests/scripts

## Validation
- `python -m pytest tests/experiments/test_nocturnal_summarizer.py -q` → **13 passed**
- `python -m py_compile` across all newly added/modified analysis modules/scripts
- `python scripts/analysis/build_grand_summary.py --help` executes successfully

Related tracking: #422