### PR TITLE
Add portable experiment sweep orchestration scripts

### DIFF
--- a/scripts/experiments/deepar_ctx_ablation_eval.sh
+++ b/scripts/experiments/deepar_ctx_ablation_eval.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# deepar_ctx_ablation_eval.sh
+#
+# Evaluates the 3 DeepAR context-ablation configs (256/128/64ctx variants of
+# winning 10_low_lr). Fine-tuned only. JOBS_PER_GPU=10 (eval is VRAM-light).
+#
+# Results land in:
+#   experiments/nocturnal_forecasting_ctx_ablation/{ctx}ctx_96fh/deepar/
+#
+# Checkpoint paths are read from:
+#   trained_models/artifacts/deepar/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/deepar_ctx_ablation_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=10 bash scripts/experiments/deepar_ctx_ablation_eval.sh 2>&1 | tee logs/ctx_ablation_deepar_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/deepar/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== DeepAR ctx-ablation eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run deepar_ctx_ablation_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "10_low_lr_256ctx|256||ALL"
+    "10_low_lr_128ctx|128||ALL"
+    "10_low_lr_64ctx|64||ALL"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/deepar_ctx_ablation_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+# Tamborlane balance sort: spread tamborlane_2008 jobs evenly across slots
+mapfile -t JOBS < <(printf '%s\n' "${JOBS[@]}" | sort -t'|' -k4,4)
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-10}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/deepar/ctx_ablation/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        local timestamp
+        timestamp="$(date +%Y-%m-%d_%H%M%S)"
+        local output_dir="experiments/nocturnal_forecasting_ctx_ablation/${ctx_len}ctx_96fh/deepar/${timestamp}_${dataset}_finetuned"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: deepar / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}]  Output:     ${output_dir}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model deepar
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --output-dir "$output_dir"
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/deepar_ctx_ablation_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/deepar_ctx_ablation_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/deepar_ctx_ablation_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== DeepAR ctx-ablation eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/deepar_ctx_ablation_train.sh
+++ b/scripts/experiments/deepar_ctx_ablation_train.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# deepar_ctx_ablation_train.sh
+#
+# Trains the 3 DeepAR context-ablation configs (256/128/64ctx variants of
+# the winning 10_low_lr config). JOBS_PER_GPU=2 (training is memory-heavy).
+#
+# Manifest: trained_models/artifacts/deepar/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/deepar_ctx_ablation_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/deepar_ctx_ablation_train.sh 2>&1 | tee logs/ctx_ablation_deepar_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== DeepAR ctx-ablation training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import DeepARModel
+print("AutoGluon DeepAR import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+
+CONFIGS=(
+    "configs/models/deepar/ctx_ablation/10_low_lr_256ctx.yaml|ALL"
+    "configs/models/deepar/ctx_ablation/10_low_lr_128ctx.yaml|ALL"
+    "configs/models/deepar/ctx_ablation/10_low_lr_64ctx.yaml|ALL"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/deepar"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: deepar / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="deepar" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/deepar_ctx_ablation_train_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/deepar_ctx_ablation_train_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/deepar_ctx_ablation_train_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== DeepAR ctx-ablation training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."

--- a/scripts/experiments/deepar_sweep_eval.sh
+++ b/scripts/experiments/deepar_sweep_eval.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# deepar_sweep_eval.sh
+#
+# Evaluates all DeepAR sweep configs (fine-tuned only — no zero-shot for
+# trained-from-scratch models). JOBS_PER_GPU parallel workers per GPU.
+#
+# Checkpoint paths are read from the manifest written by deepar_sweep_train.sh:
+#   trained_models/artifacts/deepar/sweep_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/deepar_sweep_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/deepar_sweep_eval.sh 2>&1 | tee deepar_sweep_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/deepar/sweep_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== DeepAR sweep eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run deepar_sweep_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "00_baseline|512||ALL"
+    "01_short_ctx|256||ALL"
+    "02_long_ctx|768||ALL"
+    "03_wide|512||ALL"
+    "04_narrow|512||ALL"
+    "05_deep|512||ALL"
+    "06_shallow|512||ALL"
+    "07_high_dropout|512||ALL"
+    "08_low_dropout|512||ALL"
+    "09_high_lr|512||ALL"
+    "10_low_lr|512||ALL"
+    "11_big|768||ALL"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/deepar_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/deepar/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: deepar / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model deepar
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/deepar_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/deepar_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/deepar_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== DeepAR sweep eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/deepar_sweep_train.sh
+++ b/scripts/experiments/deepar_sweep_train.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# deepar_sweep_train.sh
+#
+# Trains all DeepAR sweep configs in parallel, JOBS_PER_GPU workers per GPU.
+# Configs are distributed round-robin across all GPU slots.
+#
+# Sweep: 12 BG-only configs (DeepAR cannot consume past covariates in AG).
+# Datasets per config: aleppo_2017, brown_2019, lynch_2022, tamborlane_2008.
+#
+# Manifest: trained_models/artifacts/deepar/sweep_manifest.txt
+#
+# GPU memory: ~4 GB peak at defaults → 6 workers per 96 GB Blackwell GPU is safe.
+#
+# Usage:
+#   bash scripts/experiments/deepar_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/deepar_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/deepar_sweep_train.sh 2>&1 | tee deepar_sweep_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== DeepAR sweep training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import DeepARModel
+print("AutoGluon DeepAR import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+
+CONFIGS=(
+    "configs/models/deepar/00_baseline.yaml|ALL"
+    "configs/models/deepar/01_short_ctx.yaml|ALL"
+    "configs/models/deepar/02_long_ctx.yaml|ALL"
+    "configs/models/deepar/03_wide.yaml|ALL"
+    "configs/models/deepar/04_narrow.yaml|ALL"
+    "configs/models/deepar/05_deep.yaml|ALL"
+    "configs/models/deepar/06_shallow.yaml|ALL"
+    "configs/models/deepar/07_high_dropout.yaml|ALL"
+    "configs/models/deepar/08_low_dropout.yaml|ALL"
+    "configs/models/deepar/09_high_lr.yaml|ALL"
+    "configs/models/deepar/10_low_lr.yaml|ALL"
+    "configs/models/deepar/11_big.yaml|ALL"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/deepar"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/sweep_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-6}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: deepar / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="deepar" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/deepar_sweep_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/deepar_sweep_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/deepar_sweep_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== DeepAR sweep training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."

--- a/scripts/experiments/naive_baseline_sweep_eval.sh
+++ b/scripts/experiments/naive_baseline_sweep_eval.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# naive_baseline_sweep_eval.sh
+#
+# Evaluates Naive and Average baseline models across all 4 datasets.
+# Reads trained checkpoint paths from the manifest written by
+# naive_baseline_sweep_train.sh:
+#   trained_models/artifacts/naive_baseline/sweep_manifest.txt
+# Format: <stem>\t<output_dir>   (tab-separated, last entry per stem wins)
+#
+# NOTE: PIT histograms for these models will show miscalibration. This is
+# intentional — synthetic quantiles from residuals are reported as a contrast
+# to natively probabilistic models (NPTS, DeepAR, PatchTST, TFT, Chronos-2).
+#
+# CPU-only. No GPU required.
+# Use JOBS_PER_CPU to parallelise across datasets (default: nproc / 2).
+#
+# Usage:
+#   bash scripts/experiments/naive_baseline_sweep_eval.sh
+#   JOBS_PER_CPU=4 bash scripts/experiments/naive_baseline_sweep_eval.sh 2>&1 | tee logs/naive_sweep_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+MANIFEST="trained_models/artifacts/naive_baseline/sweep_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# Smoke-test import: confirm AutoGluon Naive/Average are available
+# ---------------------------------------------------------------------------
+echo "=== Naive Baseline sweep eval  $(date) ==="
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries import TimeSeriesPredictor
+print("AutoGluon import OK")
+EOF
+echo ""
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run naive_baseline_sweep_train.sh first."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Config definitions — "stem|context_length"
+# All naive/average configs use the full dataset set (BG-only, no covariates)
+# ---------------------------------------------------------------------------
+CONFIGS=(
+    "00_naive|512"
+    "01_average|512"
+)
+
+# ---------------------------------------------------------------------------
+# Parallelism: JOBS_PER_CPU workers (no GPU needed)
+# ---------------------------------------------------------------------------
+N_CPUS=$(nproc 2>/dev/null || echo 4)
+JOBS_PER_CPU="${JOBS_PER_CPU:-$(( N_CPUS > 8 ? N_CPUS - 8 : 1 ))}"
+[[ $JOBS_PER_CPU -lt 1 ]] && JOBS_PER_CPU=1
+echo "  CPUs available: ${N_CPUS},  parallel workers: ${JOBS_PER_CPU}"
+echo ""
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/naive_baseline_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|dataset"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIGS[@]}"; do
+    IFS='|' read -r stem ctx_len <<< "$entry"
+    for dataset in "${ALL_DATASETS[@]}"; do
+        JOBS+=("${stem}|${ctx_len}|${dataset}")
+    done
+done
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across workers
+# ---------------------------------------------------------------------------
+declare -A WORKER_JOBS
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    WORKER_JOBS[$w]=""
+done
+for i in "${!JOBS[@]}"; do
+    w=$(( i % JOBS_PER_CPU ))
+    WORKER_JOBS[$w]+="${JOBS[$i]}"$'\n'
+done
+
+# ---------------------------------------------------------------------------
+# Worker function (CPU-only)
+# ---------------------------------------------------------------------------
+run_cpu_worker() {
+    local worker="$1"
+    local jobs_block="$2"
+    local label="CPU_w${worker}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len dataset <<< "$job"
+
+        local model_config="configs/models/naive_baseline/${stem}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        # Look up checkpoint from manifest (last match wins)
+        local out_dir
+        out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+        if [[ -z "$out_dir" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — not in manifest, run naive_baseline_sweep_train.sh first"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+        local checkpoint="${PROJECT_ROOT}/${out_dir}/model.pt"
+        if [[ ! -d "$checkpoint" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint not found: $checkpoint"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: naive_baseline / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}] ============================================"
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py \
+               --model naive_baseline \
+               --model-config "$model_config" \
+               --dataset "$dataset" \
+               --config-dir "$CONFIG_DIR" \
+               --checkpoint "$checkpoint" \
+               --context-length "$ctx_len" \
+               --forecast-length 96 \
+               --probabilistic; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_cpu_worker
+export PYTHON CONFIG_DIR DONE_FILE MANIFEST PROJECT_ROOT
+
+# ---------------------------------------------------------------------------
+# Launch workers in background
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    log_file="${LOG_DIR}/naive_baseline_eval_w${w}.log"
+    echo "Launching worker ${w} → ${log_file}"
+    run_cpu_worker "$w" "${WORKER_JOBS[$w]}" > "$log_file" 2>&1 &
+    PIDS[$w]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting..."
+echo ""
+
+OVERALL_FAIL=0
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    if wait "${PIDS[$w]}"; then
+        echo "Worker ${w}: SUCCESS"
+    else
+        echo "Worker ${w}: FAILED  (see ${LOG_DIR}/naive_baseline_eval_w${w}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== Naive Baseline sweep eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} worker(s) reported failures — check logs."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/naive_baseline_sweep_train.sh
+++ b/scripts/experiments/naive_baseline_sweep_train.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# naive_baseline_sweep_train.sh
+#
+# Trains (fits) Naive and Average baseline models on all 4 datasets.
+# AutoGluon fits Naive/Average in seconds; the main cost is data loading.
+#
+# Configs:
+#   00_naive.yaml    — BG-only (Naive last-value), all 4 datasets
+#   01_average.yaml  — BG-only (Average mean), all 4 datasets
+#
+# Both configs use no covariates. tamborlane_2008 is included (BG-only is fine).
+#
+# After training, a manifest is written so naive_baseline_sweep_eval.sh can
+# locate the checkpoints for re-evaluation:
+#   trained_models/artifacts/naive_baseline/sweep_manifest.txt
+# Format: <stem>\t<output_dir>   (tab-separated, last entry per stem wins)
+#
+# CPU-only. No GPU required.
+#
+# Usage:
+#   bash scripts/experiments/naive_baseline_sweep_train.sh
+#   bash scripts/experiments/naive_baseline_sweep_train.sh 2>&1 | tee logs/naive_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ALL_DATASETS="lynch_2022 aleppo_2017 brown_2019 tamborlane_2008"
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST="trained_models/artifacts/naive_baseline/sweep_manifest.txt"
+
+# Configs: "config_path" (all use ALL datasets, BG-only)
+CONFIGS=(
+    "configs/models/naive_baseline/00_naive.yaml"
+    "configs/models/naive_baseline/01_average.yaml"
+)
+
+mkdir -p "trained_models/artifacts/naive_baseline"
+mkdir -p "logs"
+touch "$MANIFEST"
+
+PASS=0
+FAIL=0
+FAILED=()
+
+for config in "${CONFIGS[@]}"; do
+    stem="$(basename "$config" .yaml)"
+
+    # Generate run ID matching workflow convention: YYYYMMDD_HHMMSS_PID
+    RUN_ID="$(date +%Y%m%d_%H%M%S)_$$"
+    out_dir="trained_models/artifacts/naive_baseline/$(date +%Y-%m-%d_%H:%M)_RID${RUN_ID}_holdout_workflow"
+
+    echo ""
+    echo "============================================================"
+    echo "  Training: naive_baseline / $stem"
+    echo "  Config:   $config"
+    echo "  Datasets: $ALL_DATASETS"
+    echo "  Output:   $out_dir"
+    echo "============================================================"
+
+    if MODEL_TYPE="naive_baseline" \
+       VENV_NAME="chronos2" \
+       MODEL_CONFIG="$config" \
+       CONFIG_DIR="$CONFIG_DIR" \
+       DATASETS="$ALL_DATASETS" \
+       SKIP_TRAINING="false" \
+       SKIP_STEPS="1 2 4 7" \
+       OUTPUT_BASE_DIR="$out_dir" \
+       RUN_ID="$RUN_ID" \
+       "$WORKFLOW"; then
+        echo "[OK] naive_baseline / $stem"
+        echo "${stem}	${out_dir}" >> "$MANIFEST"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] naive_baseline / $stem"
+        FAIL=$((FAIL + 1))
+        FAILED+=("naive_baseline / $stem")
+    fi
+done
+
+echo ""
+echo "============================================================"
+echo "  Naive baseline training complete  $(date)"
+echo "  Passed: $PASS / $((PASS + FAIL))"
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "  Failed:"
+    for f in "${FAILED[@]}"; do
+        echo "    - $f"
+    done
+fi
+echo "  Manifest: $MANIFEST"
+echo "============================================================"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/experiments/patchtst_ctx_ablation_eval.sh
+++ b/scripts/experiments/patchtst_ctx_ablation_eval.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# patchtst_ctx_ablation_eval.sh
+#
+# Evaluates the 3 PatchTST context-ablation configs (256/128/64ctx variants of
+# winning 09_high_lr). Fine-tuned only. JOBS_PER_GPU=10 (eval is VRAM-light).
+#
+# Results land in:
+#   experiments/nocturnal_forecasting_ctx_ablation/{ctx}ctx_96fh/patchtst/
+#
+# Checkpoint paths are read from:
+#   trained_models/artifacts/patchtst/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/patchtst_ctx_ablation_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=10 bash scripts/experiments/patchtst_ctx_ablation_eval.sh 2>&1 | tee logs/ctx_ablation_patchtst_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/patchtst/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== PatchTST ctx-ablation eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run patchtst_ctx_ablation_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "09_high_lr_256ctx|256||ALL"
+    "09_high_lr_128ctx|128||ALL"
+    "09_high_lr_64ctx|64||ALL"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/patchtst_ctx_ablation_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+# Tamborlane balance sort: spread tamborlane_2008 jobs evenly across slots
+mapfile -t JOBS < <(printf '%s\n' "${JOBS[@]}" | sort -t'|' -k4,4)
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-10}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/patchtst/ctx_ablation/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        local timestamp
+        timestamp="$(date +%Y-%m-%d_%H%M%S)"
+        local output_dir="experiments/nocturnal_forecasting_ctx_ablation/${ctx_len}ctx_96fh/patchtst/${timestamp}_${dataset}_finetuned"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: patchtst / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}]  Output:     ${output_dir}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model patchtst
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --output-dir "$output_dir"
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/patchtst_ctx_ablation_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/patchtst_ctx_ablation_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/patchtst_ctx_ablation_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== PatchTST ctx-ablation eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/patchtst_ctx_ablation_train.sh
+++ b/scripts/experiments/patchtst_ctx_ablation_train.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# patchtst_ctx_ablation_train.sh
+#
+# Trains the 3 PatchTST context-ablation configs (256/128/64ctx variants of
+# the winning 09_high_lr config). JOBS_PER_GPU=2 (training is memory-heavy).
+#
+# Manifest: trained_models/artifacts/patchtst/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/patchtst_ctx_ablation_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/patchtst_ctx_ablation_train.sh 2>&1 | tee logs/ctx_ablation_patchtst_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== PatchTST ctx-ablation training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import PatchTSTModel
+print("AutoGluon PatchTST import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+
+CONFIGS=(
+    "configs/models/patchtst/ctx_ablation/09_high_lr_256ctx.yaml|ALL"
+    "configs/models/patchtst/ctx_ablation/09_high_lr_128ctx.yaml|ALL"
+    "configs/models/patchtst/ctx_ablation/09_high_lr_64ctx.yaml|ALL"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/patchtst"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: patchtst / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="patchtst" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/patchtst_ctx_ablation_train_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/patchtst_ctx_ablation_train_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/patchtst_ctx_ablation_train_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== PatchTST ctx-ablation training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."

--- a/scripts/experiments/patchtst_sweep_eval.sh
+++ b/scripts/experiments/patchtst_sweep_eval.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# patchtst_sweep_eval.sh
+#
+# Evaluates all PatchTST sweep configs (fine-tuned only — no zero-shot for
+# trained-from-scratch models). JOBS_PER_GPU parallel workers per GPU.
+#
+# Checkpoint paths are read from the manifest written by patchtst_sweep_train.sh:
+#   trained_models/artifacts/patchtst/sweep_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/patchtst_sweep_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/patchtst_sweep_eval.sh 2>&1 | tee patchtst_sweep_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/patchtst/sweep_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== PatchTST sweep eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run patchtst_sweep_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "00_baseline|512||ALL"
+    "01_short_patch|512||ALL"
+    "02_long_patch|512||ALL"
+    "03_short_ctx|256||ALL"
+    "04_long_ctx|768||ALL"
+    "05_narrow_d|512||ALL"
+    "06_wide_d|512||ALL"
+    "07_deep|512||ALL"
+    "08_shallow|512||ALL"
+    "09_high_lr|512||ALL"
+    "10_low_lr|512||ALL"
+    "11_weight_decay|512||ALL"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/patchtst_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/patchtst/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: patchtst / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model patchtst
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/patchtst_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/patchtst_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/patchtst_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== PatchTST sweep eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/patchtst_sweep_train.sh
+++ b/scripts/experiments/patchtst_sweep_train.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# patchtst_sweep_train.sh
+#
+# Trains all PatchTST sweep configs in parallel, JOBS_PER_GPU workers per GPU.
+# Configs are distributed round-robin across all GPU slots.
+#
+# Sweep: 12 BG-only configs (PatchTST cannot consume past covariates in AG).
+# Datasets per config: aleppo_2017, brown_2019, lynch_2022, tamborlane_2008.
+#
+# Manifest: trained_models/artifacts/patchtst/sweep_manifest.txt
+#
+# GPU memory: ~6 GB peak at defaults → 6 workers per 96 GB Blackwell GPU is safe.
+#
+# Usage:
+#   bash scripts/experiments/patchtst_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/patchtst_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/patchtst_sweep_train.sh 2>&1 | tee patchtst_sweep_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== PatchTST sweep training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import PatchTSTModel
+print("AutoGluon PatchTST import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+
+CONFIGS=(
+    "configs/models/patchtst/00_baseline.yaml|ALL"
+    "configs/models/patchtst/01_short_patch.yaml|ALL"
+    "configs/models/patchtst/02_long_patch.yaml|ALL"
+    "configs/models/patchtst/03_short_ctx.yaml|ALL"
+    "configs/models/patchtst/04_long_ctx.yaml|ALL"
+    "configs/models/patchtst/05_narrow_d.yaml|ALL"
+    "configs/models/patchtst/06_wide_d.yaml|ALL"
+    "configs/models/patchtst/07_deep.yaml|ALL"
+    "configs/models/patchtst/08_shallow.yaml|ALL"
+    "configs/models/patchtst/09_high_lr.yaml|ALL"
+    "configs/models/patchtst/10_low_lr.yaml|ALL"
+    "configs/models/patchtst/11_weight_decay.yaml|ALL"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/patchtst"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/sweep_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-6}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: patchtst / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="patchtst" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/patchtst_sweep_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/patchtst_sweep_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/patchtst_sweep_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== PatchTST sweep training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."

--- a/scripts/experiments/run_ctx_ablation_sweeps.sh
+++ b/scripts/experiments/run_ctx_ablation_sweeps.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# run_ctx_ablation_sweeps.sh
+#
+# Orchestrator for the full context-ablation pipeline:
+#   deepar train → patchtst train → tft train →
+#   deepar eval  → patchtst eval  → tft eval
+#
+# Each stage must succeed before the next begins.
+# Per-stage logs: logs/ctx_ablation_{model}_{train,eval}.log
+#
+# Usage:
+#   bash scripts/experiments/run_ctx_ablation_sweeps.sh
+#   nohup bash scripts/experiments/run_ctx_ablation_sweeps.sh \
+#     > logs/ctx_ablation_chain.log 2>&1 &
+#   echo "PID: $!"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR"
+
+run_stage() {
+    local stage_name="$1"
+    local script="$2"
+    local log_file="$3"
+
+    echo ""
+    echo "========================================================"
+    echo "  STAGE: ${stage_name}"
+    echo "  Script: ${script}"
+    echo "  Log:    ${log_file}"
+    echo "  Start:  $(date)"
+    echo "========================================================"
+
+    if bash "$script" > "$log_file" 2>&1; then
+        echo "  [OK] ${stage_name} completed at $(date)"
+    else
+        echo "  [FAIL] ${stage_name} FAILED at $(date)"
+        echo "  See ${log_file} for details."
+        exit 1
+    fi
+}
+
+echo "========================================================"
+echo "  Context Ablation Sweep — Full Pipeline"
+echo "  Start: $(date)"
+echo "========================================================"
+
+run_stage "DeepAR train" \
+    "scripts/experiments/deepar_ctx_ablation_train.sh" \
+    "${LOG_DIR}/ctx_ablation_deepar_train.log"
+
+run_stage "PatchTST train" \
+    "scripts/experiments/patchtst_ctx_ablation_train.sh" \
+    "${LOG_DIR}/ctx_ablation_patchtst_train.log"
+
+run_stage "TFT train" \
+    "scripts/experiments/tft_ctx_ablation_train.sh" \
+    "${LOG_DIR}/ctx_ablation_tft_train.log"
+
+run_stage "DeepAR eval" \
+    "scripts/experiments/deepar_ctx_ablation_eval.sh" \
+    "${LOG_DIR}/ctx_ablation_deepar_eval.log"
+
+run_stage "PatchTST eval" \
+    "scripts/experiments/patchtst_ctx_ablation_eval.sh" \
+    "${LOG_DIR}/ctx_ablation_patchtst_eval.log"
+
+run_stage "TFT eval" \
+    "scripts/experiments/tft_ctx_ablation_eval.sh" \
+    "${LOG_DIR}/ctx_ablation_tft_eval.log"
+
+echo ""
+echo "========================================================"
+echo "  Context Ablation Sweep — ALL STAGES COMPLETE"
+echo "  End: $(date)"
+echo "========================================================"
+echo ""
+echo "Results in: experiments/nocturnal_forecasting_ctx_ablation/"
+echo "  512ctx_96fh/  — anchor results (copied from sweep)"
+echo "  256ctx_96fh/  — ablation level"
+echo "  128ctx_96fh/  — ablation level"
+echo "  64ctx_96fh/   — ablation level"

--- a/scripts/experiments/run_overnight_deep_sweeps.sh
+++ b/scripts/experiments/run_overnight_deep_sweeps.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# run_overnight_deep_sweeps.sh
+#
+# Sequentially runs the DeepAR -> PatchTST -> TFT sweeps end-to-end.
+# Each stage is independent: a failure in one stage does NOT abort the chain.
+# After every stage we diff the model's sweep_manifest.txt against the YAMLs
+# under configs/models/<model>/ and append any missing stems to a master
+# retry manifest so we can re-launch them tomorrow.
+#
+# Outputs:
+#   logs/overnight_chain.log                — top-level orchestrator log
+#   logs/overnight_<model>_train.log        — per-stage stdout/stderr
+#   logs/overnight_failed_retry.txt         — TSV: <model>\t<config_path>\t<datasets_key>
+#
+# Usage:
+#   nohup bash scripts/experiments/run_overnight_deep_sweeps.sh \
+#       > logs/overnight_chain.log 2>&1 &
+#
+# Tail with:
+#   tail -f logs/overnight_chain.log
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR"
+
+CHAIN_LOG="${LOG_DIR}/overnight_chain.log"
+RETRY_FILE="${LOG_DIR}/overnight_failed_retry.txt"
+: > "$RETRY_FILE"
+
+# ---------------------------------------------------------------------------
+# Parse a sweep_train.sh CONFIGS=( ... ) array into TSV: stem<TAB>path<TAB>key
+# ---------------------------------------------------------------------------
+parse_sweep_configs() {
+    local sweep_script="$1"
+    awk '
+        /^CONFIGS=\(/ { in_arr=1; next }
+        in_arr && /^\)/ { in_arr=0; next }
+        in_arr {
+            line=$0
+            gsub(/^[[:space:]]*"/, "", line)
+            gsub(/"[[:space:]]*$/, "", line)
+            n = split(line, parts, "|")
+            if (n == 2) {
+                path = parts[1]
+                key  = parts[2]
+                m = split(path, segs, "/")
+                stem = segs[m]
+                sub(/\.yaml$/, "", stem)
+                printf "%s\t%s\t%s\n", stem, path, key
+            }
+        }
+    ' "$sweep_script"
+}
+
+# ---------------------------------------------------------------------------
+# After a stage, append failed configs (those not in manifest) to RETRY_FILE
+# ---------------------------------------------------------------------------
+record_failures() {
+    local model="$1"
+    local sweep_script="$2"
+    local manifest="trained_models/artifacts/${model}/sweep_manifest.txt"
+    [[ -f "$manifest" ]] || touch "$manifest"
+
+    local total=0 ok=0 missing=0
+    while IFS=$'\t' read -r stem path key; do
+        [[ -z "$stem" ]] && continue
+        total=$(( total + 1 ))
+        if awk -F'\t' -v s="$stem" '$1 == s { found=1 } END { exit !found }' "$manifest"; then
+            ok=$(( ok + 1 ))
+        else
+            missing=$(( missing + 1 ))
+            printf '%s\t%s\t%s\n' "$model" "$path" "$key" >> "$RETRY_FILE"
+        fi
+    done < <(parse_sweep_configs "$sweep_script")
+
+    echo "[chain] ${model}: ${ok}/${total} succeeded, ${missing} need retry"
+}
+
+# ---------------------------------------------------------------------------
+# Run one stage; never aborts the chain
+# ---------------------------------------------------------------------------
+run_stage() {
+    local model="$1"
+    local sweep_script="scripts/experiments/${model}_sweep_train.sh"
+    local stage_log="${LOG_DIR}/overnight_${model}_train.log"
+
+    echo ""
+    echo "[chain] ============================================================"
+    echo "[chain]  Stage: ${model}    started $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "[chain]  Script: ${sweep_script}"
+    echo "[chain]  Log:    ${stage_log}"
+    echo "[chain] ============================================================"
+
+    if [[ ! -x "$sweep_script" && ! -f "$sweep_script" ]]; then
+        echo "[chain] ERROR: sweep script not found: ${sweep_script}"
+        return 0
+    fi
+
+    local rc=0
+    bash "$sweep_script" > "$stage_log" 2>&1 || rc=$?
+    echo "[chain]  Stage: ${model}    finished $(date '+%Y-%m-%d %H:%M:%S')  exit=${rc}"
+    record_failures "$model" "$sweep_script"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run the chain
+# ---------------------------------------------------------------------------
+echo "[chain] === Overnight deep sweep chain  $(date '+%Y-%m-%d %H:%M:%S') ==="
+echo "[chain] Project: ${PROJECT_ROOT}"
+echo "[chain] Retry manifest: ${RETRY_FILE}"
+
+run_stage deepar
+run_stage patchtst
+run_stage tft
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+total_failures=$(grep -c '' "$RETRY_FILE" 2>/dev/null || echo 0)
+
+echo ""
+echo "[chain] ============================================================"
+echo "[chain]  Chain complete  $(date '+%Y-%m-%d %H:%M:%S')"
+echo "[chain]  Stages run: deepar, patchtst, tft"
+echo "[chain]  Total failed configs: ${total_failures}"
+echo "[chain]  Retry manifest: ${RETRY_FILE}"
+if [[ "$total_failures" -gt 0 ]]; then
+    echo "[chain]  --- Failed configs ---"
+    cat "$RETRY_FILE"
+fi
+echo "[chain] ============================================================"

--- a/scripts/experiments/statistical_sweep_eval.sh
+++ b/scripts/experiments/statistical_sweep_eval.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# statistical_sweep_eval.sh
+#
+# Evaluates all statistical baseline models from the trained manifest.
+# CPU-only. Uses JOBS_PER_CPU parallel workers (default: nproc / 2).
+#
+# Checkpoint paths are read from the manifest written by statistical_sweep_train.sh:
+#   trained_models/artifacts/statistical/sweep_manifest.txt
+# Format: <stem>\t<output_dir>  (tab-separated, last entry wins on re-run)
+#
+# Usage:
+#   bash scripts/experiments/statistical_sweep_eval.sh
+#   JOBS_PER_CPU=4 bash scripts/experiments/statistical_sweep_eval.sh 2>&1 | tee statistical_sweep_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/statistical/sweep_manifest.txt"
+LOG_DIR="logs"
+
+echo "=== Statistical sweep eval  $(date) ==="
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run statistical_sweep_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|context_length|space-separated covariate cols|datasets_key"
+CONFIG_META=(
+    "00_autoarima_bg_only|512||ALL"
+    "01_autoarima_bg_iob|512|iob|IOB"
+    "02_theta_bg_only|512||ALL"
+    "03_npts_bg_only|512||ALL"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/statistical_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            echo "[WARN] ${stem} — not in manifest, jobs will be skipped"
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            echo "[WARN] ${stem} — output dir missing: ${checkpoint}"
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Parallelism (CPU-only)
+# ---------------------------------------------------------------------------
+N_CPUS=$(nproc 2>/dev/null || echo 4)
+JOBS_PER_CPU="${JOBS_PER_CPU:-$(( N_CPUS > 8 ? N_CPUS - 8 : 1 ))}"
+[[ $JOBS_PER_CPU -lt 1 ]] && JOBS_PER_CPU=1
+echo "  CPUs available: ${N_CPUS},  parallel workers: ${JOBS_PER_CPU}"
+echo ""
+
+declare -A WORKER_JOBS
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    WORKER_JOBS[$w]=""
+done
+for i in "${!JOBS[@]}"; do
+    w=$(( i % JOBS_PER_CPU ))
+    WORKER_JOBS[$w]+="${JOBS[$i]}"$'\n'
+done
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_cpu_worker() {
+    local worker="$1"
+    local jobs_block="$2"
+    local label="CPU_w${worker}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/statistical/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: statistical / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model statistical
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_cpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    log_file="${LOG_DIR}/statistical_eval_w${w}.log"
+    echo "Launching worker ${w} → ${log_file}"
+    run_cpu_worker "$w" "${WORKER_JOBS[$w]}" > "$log_file" 2>&1 &
+    PIDS[$w]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting..."
+echo ""
+
+OVERALL_FAIL=0
+for (( w=0; w<JOBS_PER_CPU; w++ )); do
+    if wait "${PIDS[$w]}"; then
+        echo "Worker ${w}: SUCCESS"
+    else
+        echo "Worker ${w}: FAILED  (see ${LOG_DIR}/statistical_eval_w${w}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== Statistical sweep eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/statistical_sweep_train.sh
+++ b/scripts/experiments/statistical_sweep_train.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# statistical_sweep_train.sh
+#
+# Trains all statistical baseline models (AutoARIMA, Theta, NPTS) on the
+# appropriate dataset subsets. AutoGluon must fit these models to compute
+# residual distributions for quantile synthesis.
+#
+# Configs:
+#   00_autoarima_bg_only  — all 4 datasets
+#   01_autoarima_bg_iob   — IOB datasets only (aleppo_2017, brown_2019, lynch_2022)
+#   02_theta_bg_only      — all 4 datasets
+#   03_npts_bg_only       — all 4 datasets
+#
+# Each config has a 2h time_limit. Series not fit in time fall back to Naive.
+# CPU-only. No GPU required.
+#
+# Usage:
+#   bash scripts/experiments/statistical_sweep_train.sh
+#   bash scripts/experiments/statistical_sweep_train.sh 2>&1 | tee statistical_sweep_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+DATASETS_ALL="lynch_2022 aleppo_2017 brown_2019 tamborlane_2008"
+DATASETS_WITH_IOB="lynch_2022 aleppo_2017 brown_2019"
+MANIFEST_DIR="trained_models/artifacts/statistical"
+MANIFEST="${MANIFEST_DIR}/sweep_manifest.txt"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+LOG_DIR="logs"
+
+echo "=== Statistical sweep training  $(date) ==="
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import AutoARIMAModel, ThetaModel, NPTSModel
+print("AutoGluon statistical model import OK (AutoARIMA, Theta, NPTS)")
+EOF
+echo ""
+
+# Format: "config_path|datasets_key"
+CONFIGS=(
+    "configs/models/statistical/00_autoarima_bg_only.yaml|ALL"
+    "configs/models/statistical/01_autoarima_bg_iob.yaml|IOB"
+    "configs/models/statistical/02_theta_bg_only.yaml|ALL"
+    "configs/models/statistical/03_npts_bg_only.yaml|ALL"
+)
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+PASS=0
+FAIL=0
+FAILED=()
+
+for entry in "${CONFIGS[@]}"; do
+    IFS='|' read -r config datasets_key <<< "$entry"
+    stem="$(basename "$config" .yaml)"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        datasets="$DATASETS_WITH_IOB"
+    else
+        datasets="$DATASETS_ALL"
+    fi
+
+    # Skip if already in manifest with a valid output dir
+    existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+    if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+        echo "[SKIP] ${stem} — already in manifest: $(basename "$existing_dir")"
+        PASS=$(( PASS + 1 ))
+        continue
+    fi
+
+    run_id="$(date +%Y%m%d_%H%M%S)_$$"
+    out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+    echo ""
+    echo "============================================================"
+    echo "  Training: statistical / ${stem}"
+    echo "  Config:   ${config}"
+    echo "  Datasets: ${datasets}"
+    echo "  Output:   ${out_dir}"
+    echo "  Note:     2h time_limit — unfit series fall back to Naive"
+    echo "============================================================"
+
+    if MODEL_TYPE="statistical" \
+       VENV_NAME="chronos2" \
+       MODEL_CONFIG="$config" \
+       CONFIG_DIR="$CONFIG_DIR" \
+       DATASETS="$datasets" \
+       SKIP_TRAINING="false" \
+       SKIP_STEPS="$SKIP_STEPS" \
+       OUTPUT_BASE_DIR="$out_dir" \
+       RUN_ID="$run_id" \
+       "$WORKFLOW"; then
+        echo "[OK] statistical / ${stem}"
+        echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+
+        # Print leaderboard + per-series fallback count
+        "$PYTHON" - "$out_dir" <<'PYEOF'
+import sys, pathlib
+try:
+    from autogluon.timeseries import TimeSeriesPredictor
+    predictor_dir = pathlib.Path(sys.argv[1])
+    p = TimeSeriesPredictor.load(str(predictor_dir))
+    print("\n--- AutoGluon leaderboard ---")
+    print(p.leaderboard().to_string(index=False))
+    info = p.info()
+    print(f"\n--- Fit info ---")
+    print(f"  num_train_rows : {info.get('num_train_rows', 'n/a')}")
+    train_time = info.get('train_time')
+    print(f"  train_time_s   : {train_time:.1f}" if isinstance(train_time, float) else f"  train_time_s   : {train_time}")
+
+    # Per-series fallback count: AutoGluon local models (AutoARIMA, Theta, NPTS)
+    # store one fitted object per item_id in model.local_models. Items that
+    # timed out are replaced with a SimpleExpSmoothing/Naive fallback whose
+    # class name differs from the primary model class.
+    try:
+        trainer = p._learner.load_trainer()
+        for model_name in trainer.get_model_names():
+            m = trainer.load_model(model_name)
+            local = getattr(m, "local_models", None)
+            if local:
+                primary_cls = type(next(iter(local.values()))).__name__
+                fallback_count = sum(
+                    1 for v in local.values() if type(v).__name__ != primary_cls
+                )
+                total = len(local)
+                print(f"\n  {model_name}: {total - fallback_count}/{total} series fit successfully "
+                      f"({fallback_count} fell back to a simpler model)")
+    except Exception as inner:
+        print(f"  [fallback count unavailable: {inner}]")
+        print("  (check the training log above for 'fallback' or 'time limit' messages)")
+
+    print("-----------------------------\n")
+except Exception as e:
+    print(f"[WARN] Could not print leaderboard: {e}")
+PYEOF
+
+        PASS=$(( PASS + 1 ))
+    else
+        echo "[FAIL] statistical / ${stem}"
+        FAIL=$(( FAIL + 1 ))
+        FAILED+=("statistical / ${stem}")
+    fi
+done
+
+echo ""
+echo "============================================================"
+echo "  Statistical sweep training complete  $(date)"
+echo "  Passed: ${PASS} / $(( PASS + FAIL ))"
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "  Failed:"
+    for f in "${FAILED[@]}"; do
+        echo "    - $f"
+    done
+fi
+echo "============================================================"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/experiments/sundial_sweep_eval.sh
+++ b/scripts/experiments/sundial_sweep_eval.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# sundial_sweep_eval.sh
+#
+# Evaluates Sundial in zero-shot mode across all four holdout datasets with
+# full probabilistic and DILATE metrics.
+#
+# Sundial is a foundation model — no fine-tuning or checkpoint required.
+# Config: configs/models/sundial/02_low_samples.yaml  (num_samples=20)
+#
+# All four datasets are evaluated — Sundial has no covariate support.
+#
+# Usage:
+#   bash scripts/experiments/sundial_sweep_eval.sh
+#   CUDA_DEVICE=1 bash scripts/experiments/sundial_sweep_eval.sh
+#   DATASETS="lynch_2022" bash scripts/experiments/sundial_sweep_eval.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/sundial/bin/python"
+GPU="${CUDA_DEVICE:-0}"
+CONFIG_DIR="${CONFIG_DIR:-configs/data/holdout_10pct}"
+MODEL_CONFIG="configs/models/sundial/02_low_samples.yaml"
+REQUESTED_DATASETS_STR="${DATASETS:-lynch_2022 aleppo_2017 brown_2019 tamborlane_2008}"
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: sundial venv not found at $PYTHON"
+    exit 1
+fi
+
+IFS=' ' read -r -a DATASETS_ARR <<< "$REQUESTED_DATASETS_STR"
+
+PASS=0
+FAIL=0
+FAILED=()
+
+for dataset in "${DATASETS_ARR[@]}"; do
+    label="sundial / 02_low_samples / ${dataset}"
+    echo ""
+    echo "============================================================"
+    echo "  Eval: ${label}"
+    echo "============================================================"
+
+    CMD=(
+        "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py
+        --model sundial
+        --model-config "$MODEL_CONFIG"
+        --dataset "$dataset"
+        --config-dir "$CONFIG_DIR"
+        --context-length 512
+        --forecast-length 96
+        --cuda-device "$GPU"
+        --probabilistic
+    )
+
+    if "${CMD[@]}"; then
+        echo "[OK] ${label}"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] ${label}"
+        FAIL=$((FAIL + 1))
+        FAILED+=("${label}")
+    fi
+done
+
+echo ""
+echo "============================================================"
+echo "  Sundial sweep eval complete  $(date)"
+echo "  Passed: ${PASS} / $((PASS + FAIL))"
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "  Failed:"
+    for f in "${FAILED[@]}"; do
+        echo "    - ${f}"
+    done
+fi
+echo "============================================================"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/experiments/tft_ctx_ablation_eval.sh
+++ b/scripts/experiments/tft_ctx_ablation_eval.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# tft_ctx_ablation_eval.sh
+#
+# Evaluates the 6 TFT context-ablation configs:
+#   BG winner (01_bg_wide):       256/128/64ctx → all 4 datasets  (12 jobs)
+#   IOB winner (11_iob_high_lr):  256/128/64ctx → 3 IOB datasets  (9 jobs)
+#   Total: 21 eval jobs
+#
+# Fine-tuned only. JOBS_PER_GPU=10 (eval is VRAM-light).
+#
+# Results land in:
+#   experiments/nocturnal_forecasting_ctx_ablation/{ctx}ctx_96fh/tft/
+#
+# Checkpoint paths are read from:
+#   trained_models/artifacts/tft/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/tft_ctx_ablation_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=10 bash scripts/experiments/tft_ctx_ablation_eval.sh 2>&1 | tee logs/ctx_ablation_tft_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+MANIFEST="trained_models/artifacts/tft/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== TFT ctx-ablation eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run tft_ctx_ablation_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "01_bg_wide_256ctx|256||ALL"
+    "01_bg_wide_128ctx|128||ALL"
+    "01_bg_wide_64ctx|64||ALL"
+    "11_iob_high_lr_256ctx|256|iob|IOB"
+    "11_iob_high_lr_128ctx|128|iob|IOB"
+    "11_iob_high_lr_64ctx|64|iob|IOB"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/tft_ctx_ablation_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+# Tamborlane balance sort: spread tamborlane_2008 jobs evenly across slots
+mapfile -t JOBS < <(printf '%s\n' "${JOBS[@]}" | sort -t'|' -k4,4)
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-10}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/tft/ctx_ablation/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        local timestamp
+        timestamp="$(date +%Y-%m-%d_%H%M%S)"
+        local output_dir="experiments/nocturnal_forecasting_ctx_ablation/${ctx_len}ctx_96fh/tft/${timestamp}_${dataset}_finetuned"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: tft / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}]  Output:     ${output_dir}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model tft
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --output-dir "$output_dir"
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/tft_ctx_ablation_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/tft_ctx_ablation_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/tft_ctx_ablation_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== TFT ctx-ablation eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/tft_ctx_ablation_train.sh
+++ b/scripts/experiments/tft_ctx_ablation_train.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# tft_ctx_ablation_train.sh
+#
+# Trains the 6 TFT context-ablation configs:
+#   - BG winner (01_bg_wide): 256/128/64ctx  →  all 4 datasets
+#   - IOB winner (11_iob_high_lr): 256/128/64ctx  →  IOB-bearing datasets only
+#
+# JOBS_PER_GPU=2 (training is memory-heavy).
+#
+# Manifest: trained_models/artifacts/tft/ctx_ablation_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/tft_ctx_ablation_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/tft_ctx_ablation_train.sh 2>&1 | tee logs/ctx_ablation_tft_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== TFT ctx-ablation training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import TemporalFusionTransformerModel
+print("AutoGluon TFT import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+
+CONFIGS=(
+    "configs/models/tft/ctx_ablation/01_bg_wide_256ctx.yaml|ALL"
+    "configs/models/tft/ctx_ablation/01_bg_wide_128ctx.yaml|ALL"
+    "configs/models/tft/ctx_ablation/01_bg_wide_64ctx.yaml|ALL"
+    "configs/models/tft/ctx_ablation/11_iob_high_lr_256ctx.yaml|IOB"
+    "configs/models/tft/ctx_ablation/11_iob_high_lr_128ctx.yaml|IOB"
+    "configs/models/tft/ctx_ablation/11_iob_high_lr_64ctx.yaml|IOB"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/tft"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/ctx_ablation_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: tft / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="tft" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/tft_ctx_ablation_train_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/tft_ctx_ablation_train_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/tft_ctx_ablation_train_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== TFT ctx-ablation training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."

--- a/scripts/experiments/tft_sweep_eval.sh
+++ b/scripts/experiments/tft_sweep_eval.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# tft_sweep_eval.sh
+#
+# Evaluates all TFT sweep configs (fine-tuned only — no zero-shot for
+# trained-from-scratch models). JOBS_PER_GPU parallel workers per GPU.
+#
+# Checkpoint paths are read from the manifest written by tft_sweep_train.sh:
+#   trained_models/artifacts/tft/sweep_manifest.txt
+#
+# Usage:
+#   bash scripts/experiments/tft_sweep_eval.sh
+#   GPUS="0 1" JOBS_PER_GPU=2 bash scripts/experiments/tft_sweep_eval.sh 2>&1 | tee tft_sweep_eval.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+CONFIG_DIR="configs/data/holdout_10pct"
+ALL_DATASETS=(lynch_2022 aleppo_2017 brown_2019 tamborlane_2008)
+DATASETS_WITH_IOB=(lynch_2022 aleppo_2017 brown_2019)
+DATASETS_IOB_COB=(aleppo_2017)
+MANIFEST="trained_models/artifacts/tft/sweep_manifest.txt"
+LOG_DIR="logs"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== TFT sweep eval  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: manifest not found at $MANIFEST"
+    echo "       Run tft_sweep_train.sh first."
+    exit 1
+fi
+
+# Format: "stem|ctx_len|cov_cols|datasets_key"
+CONFIG_META=(
+    "00_bg_baseline|512||ALL"
+    "01_bg_wide|512||ALL"
+    "02_bg_long_ctx|768||ALL"
+    "03_bg_high_dropout|512||ALL"
+    "04_bg_more_heads|512||ALL"
+    "05_bg_high_lr|512||ALL"
+    "06_iob_baseline|512|iob|IOB"
+    "07_iob_wide|512|iob|IOB"
+    "08_iob_long_ctx|768|iob|IOB"
+    "09_iob_high_dropout|512|iob|IOB"
+    "10_iob_more_heads|512|iob|IOB"
+    "11_iob_high_lr|512|iob|IOB"
+    "12_iob_cob_baseline|512|iob cob|ALEPPO"
+    "13_iob_cob_wide|512|iob cob|ALEPPO"
+    "14_iob_cob_high_dropout|512|iob cob|ALEPPO"
+    "15_iob_cob_more_heads|512|iob cob|ALEPPO"
+    "16_iob_cob_high_lr|512|iob cob|ALEPPO"
+)
+
+mkdir -p "$LOG_DIR"
+DONE_FILE="${LOG_DIR}/tft_eval_done.log"
+touch "$DONE_FILE"
+
+# ---------------------------------------------------------------------------
+# Build flat job list: "stem|ctx_len|cov_cols|dataset|checkpoint"
+# ---------------------------------------------------------------------------
+JOBS=()
+for entry in "${CONFIG_META[@]}"; do
+    IFS='|' read -r stem ctx_len cov_cols datasets_key <<< "$entry"
+
+    if [[ "$datasets_key" == "IOB" ]]; then
+        ft_datasets=("${DATASETS_WITH_IOB[@]}")
+    elif [[ "$datasets_key" == "ALEPPO" ]]; then
+        ft_datasets=("${DATASETS_IOB_COB[@]}")
+    else
+        ft_datasets=("${ALL_DATASETS[@]}")
+    fi
+
+    out_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST")"
+    checkpoint=""
+    if [[ -n "$out_dir" ]]; then
+        checkpoint="${PROJECT_ROOT}/${out_dir}"
+    fi
+
+    for dataset in "${ft_datasets[@]}"; do
+        if [[ -z "$out_dir" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        elif [[ ! -d "$checkpoint" ]]; then
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|MISSING")
+        else
+            JOBS+=("${stem}|${ctx_len}|${cov_cols}|${dataset}|${checkpoint}")
+        fi
+    done
+done
+
+echo "Total jobs: ${#JOBS[@]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Distribute jobs across GPU slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-2}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!JOBS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${JOBS[$i]}"$'\n'
+done
+
+echo "Job distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} jobs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local jobs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r job; do
+        [[ -z "$job" ]] && continue
+        IFS='|' read -r stem ctx_len cov_cols dataset checkpoint <<< "$job"
+
+        local model_config="configs/models/tft/${stem}.yaml"
+        local data_config="${CONFIG_DIR}/${dataset}.yaml"
+        local done_key="${stem}|${dataset}"
+
+        if grep -qxF "$done_key" "$DONE_FILE" 2>/dev/null; then
+            echo "[${label}] [SKIP] ${done_key} — already done"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        if [[ "$checkpoint" == "MISSING" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — checkpoint missing"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        if [[ ! -f "$data_config" ]]; then
+            echo "[${label}] [SKIP] ${done_key} — data config not found: ${data_config}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+            continue
+        fi
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Eval: tft / ${stem} / ${dataset}"
+        echo "[${label}]  Checkpoint: ${checkpoint}"
+        echo "[${label}] ============================================"
+
+        eval_args=(
+            --model tft
+            --model-config "$model_config"
+            --dataset "$dataset"
+            --config-dir "$CONFIG_DIR"
+            --checkpoint "$checkpoint"
+            --context-length "$ctx_len"
+            --forecast-length 96
+            --cuda-device "$gpu"
+            --probabilistic
+        )
+        if [[ -n "$cov_cols" ]]; then
+            # shellcheck disable=SC2206
+            eval_args+=(--covariate-cols $cov_cols)
+        fi
+
+        if "$PYTHON" scripts/experiments/nocturnal_hypo_eval.py "${eval_args[@]}"; then
+            echo "[${label}] [OK] ${done_key}"
+            echo "$done_key" >> "$DONE_FILE"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${done_key}"
+            fail=$(( fail + 1 ))
+            failed+=("${done_key}")
+        fi
+    done <<< "$jobs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export PYTHON CONFIG_DIR DONE_FILE
+
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/tft_eval_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/tft_eval_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/tft_eval_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== TFT sweep eval complete  $(date) ==="
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs evaluated successfully."

--- a/scripts/experiments/tft_sweep_train.sh
+++ b/scripts/experiments/tft_sweep_train.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# tft_sweep_train.sh
+#
+# Trains all TFT sweep configs in parallel, JOBS_PER_GPU workers per GPU.
+# Configs are distributed round-robin across all GPU slots.
+#
+# Sweep: 12 configs total — 6 BG-only (00–05, all four datasets) and
+# 6 BG+IOB (06–11, IOB datasets only). TFT is the only deep model in the
+# stack that can consume past covariates.
+#
+# Manifest: trained_models/artifacts/tft/sweep_manifest.txt
+#
+# GPU memory: ~8 GB peak at defaults → 6 workers per 96 GB Blackwell GPU is safe.
+#
+# Usage:
+#   bash scripts/experiments/tft_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/tft_sweep_train.sh
+#   GPUS="0 1" JOBS_PER_GPU=6 bash scripts/experiments/tft_sweep_train.sh 2>&1 | tee tft_sweep_train.log
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTHON="${PROJECT_ROOT}/.venvs/chronos2/bin/python"
+
+# ---------------------------------------------------------------------------
+# GPU detection
+# ---------------------------------------------------------------------------
+if [[ -n "${GPUS:-}" ]]; then
+    read -ra GPUS_ARRAY <<< "$GPUS"
+else
+    mapfile -t GPUS_ARRAY < <(
+        nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || echo "0"
+    )
+fi
+
+N_GPUS=${#GPUS_ARRAY[@]}
+echo "=== TFT sweep training  $(date) ==="
+echo "  GPUs: ${GPUS_ARRAY[*]}  (${N_GPUS} total)"
+echo "  Venv: ${PYTHON}"
+echo ""
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: venv not found at $PYTHON"
+    exit 1
+fi
+
+# Smoke-test imports
+"$PYTHON" - <<'EOF'
+from autogluon.timeseries.models import TemporalFusionTransformerModel
+print("AutoGluon TFT import OK")
+EOF
+echo ""
+
+# ---------------------------------------------------------------------------
+# Config definitions
+# ---------------------------------------------------------------------------
+DATASETS_ALL="aleppo_2017 brown_2019 lynch_2022 tamborlane_2008"
+DATASETS_WITH_IOB="aleppo_2017 brown_2019 lynch_2022"
+DATASETS_IOB_COB="aleppo_2017"
+
+CONFIGS=(
+    "configs/models/tft/00_bg_baseline.yaml|ALL"
+    "configs/models/tft/01_bg_wide.yaml|ALL"
+    "configs/models/tft/02_bg_long_ctx.yaml|ALL"
+    "configs/models/tft/03_bg_high_dropout.yaml|ALL"
+    "configs/models/tft/04_bg_more_heads.yaml|ALL"
+    "configs/models/tft/05_bg_high_lr.yaml|ALL"
+    "configs/models/tft/06_iob_baseline.yaml|IOB"
+    "configs/models/tft/07_iob_wide.yaml|IOB"
+    "configs/models/tft/08_iob_long_ctx.yaml|IOB"
+    "configs/models/tft/09_iob_high_dropout.yaml|IOB"
+    "configs/models/tft/10_iob_more_heads.yaml|IOB"
+    "configs/models/tft/11_iob_high_lr.yaml|IOB"
+    "configs/models/tft/12_iob_cob_baseline.yaml|ALEPPO"
+    "configs/models/tft/13_iob_cob_wide.yaml|ALEPPO"
+    "configs/models/tft/14_iob_cob_high_dropout.yaml|ALEPPO"
+    "configs/models/tft/15_iob_cob_more_heads.yaml|ALEPPO"
+    "configs/models/tft/16_iob_cob_high_lr.yaml|ALEPPO"
+)
+
+CONFIG_DIR="configs/data/holdout_10pct"
+WORKFLOW="scripts/examples/run_holdout_generic_workflow.sh"
+MANIFEST_DIR="trained_models/artifacts/tft"
+SKIP_STEPS="${SKIP_STEPS:-1 2 4 7}"
+MANIFEST="${MANIFEST_DIR}/sweep_manifest.txt"
+LOG_DIR="logs"
+
+mkdir -p "$MANIFEST_DIR" "$LOG_DIR"
+touch "$MANIFEST"
+
+# ---------------------------------------------------------------------------
+# Distribute configs round-robin across slots
+# ---------------------------------------------------------------------------
+JOBS_PER_GPU="${JOBS_PER_GPU:-6}"
+N_SLOTS=$(( N_GPUS * JOBS_PER_GPU ))
+echo "  Jobs per GPU: ${JOBS_PER_GPU}  (${N_SLOTS} total slots)"
+echo ""
+
+declare -A SLOT_CONFIGS
+declare -A SLOT_GPU
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    SLOT_CONFIGS[$slot]=""
+    SLOT_GPU[$slot]="${GPUS_ARRAY[$(( slot % N_GPUS ))]}"
+done
+
+for i in "${!CONFIGS[@]}"; do
+    slot=$(( i % N_SLOTS ))
+    SLOT_CONFIGS[$slot]+="${CONFIGS[$i]}"$'\n'
+done
+
+echo "Config distribution:"
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    n=$(echo "${SLOT_CONFIGS[$slot]}" | grep -c '|' || true)
+    echo "  GPU ${gpu} worker ${slot}: ${n} configs"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+run_gpu_worker() {
+    local gpu="$1"
+    local slot="$2"
+    local configs_block="$3"
+    local label="GPU${gpu}w${slot}"
+    local pass=0 fail=0
+    local failed=()
+
+    echo "[${label}] Starting at $(date)"
+
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        IFS='|' read -r config datasets_key <<< "$entry"
+        local stem
+        stem="$(basename "$config" .yaml)"
+
+        # Skip if already in manifest
+        local existing_dir
+        existing_dir="$(awk -F'\t' -v s="$stem" '$1 == s { last=$2 } END { print last }' "$MANIFEST" 2>/dev/null || true)"
+        if [[ -n "$existing_dir" && -d "${existing_dir}" ]]; then
+            echo "[${label}] [SKIP] ${stem} — already in manifest"
+            pass=$(( pass + 1 ))
+            continue
+        fi
+
+        local datasets
+        if [[ "$datasets_key" == "IOB" ]]; then
+            datasets="$DATASETS_WITH_IOB"
+        elif [[ "$datasets_key" == "ALEPPO" ]]; then
+            datasets="$DATASETS_IOB_COB"
+        else
+            datasets="$DATASETS_ALL"
+        fi
+
+        local run_id
+        run_id="$(date +%Y%m%d_%H%M%S)_${BASHPID}"
+        local out_dir="${MANIFEST_DIR}/$(date +%Y-%m-%d_%H%M)_RID${run_id}_${stem}"
+
+        echo ""
+        echo "[${label}] ============================================"
+        echo "[${label}]  Training: tft / ${stem}"
+        echo "[${label}]  Config:   ${config}"
+        echo "[${label}]  Datasets: ${datasets}"
+        echo "[${label}]  Output:   ${out_dir}"
+        echo "[${label}] ============================================"
+
+        if CUDA_VISIBLE_DEVICES="$gpu" \
+           MODEL_TYPE="tft" \
+           VENV_NAME="chronos2" \
+           MODEL_CONFIG="$config" \
+           CONFIG_DIR="$CONFIG_DIR" \
+           DATASETS="$datasets" \
+           SKIP_TRAINING="false" \
+           SKIP_STEPS="$SKIP_STEPS" \
+           OUTPUT_BASE_DIR="$out_dir" \
+           RUN_ID="$run_id" \
+           "$WORKFLOW"; then
+            echo "[${label}] [OK] ${stem}"
+            echo "${stem}"$'\t'"${out_dir}" >> "$MANIFEST"
+            pass=$(( pass + 1 ))
+        else
+            echo "[${label}] [FAIL] ${stem}"
+            fail=$(( fail + 1 ))
+            failed+=("${stem}")
+        fi
+    done <<< "$configs_block"
+
+    echo ""
+    echo "[${label}] Done at $(date)  —  passed: ${pass} / $(( pass + fail ))"
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "[${label}] Failed: ${failed[*]}"
+        return 1
+    fi
+}
+
+export -f run_gpu_worker
+export DATASETS_ALL DATASETS_WITH_IOB MANIFEST_DIR MANIFEST CONFIG_DIR WORKFLOW SKIP_STEPS
+
+# ---------------------------------------------------------------------------
+# Launch workers
+# ---------------------------------------------------------------------------
+declare -A PIDS
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    log_file="${LOG_DIR}/tft_sweep_gpu${gpu}_w${slot}.log"
+    echo "Launching GPU ${gpu} worker ${slot} → ${log_file}"
+    run_gpu_worker "$gpu" "$slot" "${SLOT_CONFIGS[$slot]}" \
+        > "$log_file" 2>&1 &
+    PIDS[$slot]=$!
+done
+
+echo ""
+echo "All workers launched. Waiting for completion..."
+echo "(tail -f logs/tft_sweep_gpu<N>_w<slot>.log to monitor)"
+echo ""
+
+OVERALL_FAIL=0
+for (( slot=0; slot<N_SLOTS; slot++ )); do
+    gpu="${SLOT_GPU[$slot]}"
+    pid="${PIDS[$slot]}"
+    if wait "$pid"; then
+        echo "GPU ${gpu} worker ${slot}: SUCCESS"
+    else
+        echo "GPU ${gpu} worker ${slot}: FAILED  (see ${LOG_DIR}/tft_sweep_gpu${gpu}_w${slot}.log)"
+        OVERALL_FAIL=$(( OVERALL_FAIL + 1 ))
+    fi
+done
+
+echo ""
+echo "=== TFT sweep training complete  $(date) ==="
+echo "  Manifest: ${MANIFEST}"
+if [[ $OVERALL_FAIL -gt 0 ]]; then
+    echo "  ${OVERALL_FAIL} GPU worker(s) reported failures."
+    exit 1
+fi
+echo "  All configs trained successfully."


### PR DESCRIPTION
## Summary
This PR executes **PR-C** from the `feat/autogluon-baselines` extraction plan by adding portable orchestration scripts for baseline sweep and context-ablation execution.

### Included
- New sweep scripts for:
  - DeepAR
  - Naive baselines
  - PatchTST
  - Statistical baselines
  - TFT
- New orchestration helpers:
  - `run_ctx_ablation_sweeps.sh`
  - `run_overnight_deep_sweeps.sh`
- Added `sundial_sweep_eval.sh` for aligned evaluation invocation.

### Explicitly excluded
- Rerun-manifest scripts with machine-local absolute paths (`rerun_*`, `_rerun_iob_eval.sh`)
- `timegrad_eval.sh` (run-specific path coupling)
- Generated outputs / result artifacts

## Validation
- `bash -n` syntax checks on all newly added shell scripts
- Hardcoded local path scan confirms selected files do not contain `/data/home/...` style paths

Related tracking: #422