### PR TITLE
AutoGluon extraction follow-up: portable workflow + covariate guardrails

### DIFF
--- a/scripts/examples/example_holdout_generic_workflow.py
+++ b/scripts/examples/example_holdout_generic_workflow.py
@@ -47,6 +47,7 @@ Usage:
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 import traceback
@@ -873,10 +874,31 @@ class ModelFactory:
                 **moirai_kwargs,
             )
             return MoiraiForecaster.load(model_path, moirai_config)
+        elif model_type_lower == "naive_baseline":
+            from src.models.naive_baseline import NaiveBaselineForecaster
+
+            return NaiveBaselineForecaster.load(model_path)
+        elif model_type_lower == "statistical":
+            from src.models.statistical import StatisticalForecaster
+
+            return StatisticalForecaster.load(model_path)
+        elif model_type_lower == "deepar":
+            from src.models.deepar import DeepARForecaster
+
+            return DeepARForecaster.load(model_path)
+        elif model_type_lower == "patchtst":
+            from src.models.patchtst import PatchTSTForecaster
+
+            return PatchTSTForecaster.load(model_path)
+        elif model_type_lower == "tft":
+            from src.models.tft import TFTForecaster
+
+            return TFTForecaster.load(model_path)
         else:
             raise ValueError(
                 f"Unsupported model type for loading: {model_type}. "
-                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide, toto, moirai"
+                f"Supported types: ttm, chronos, chronos2, moment, timesfm, timegrad, tide, toto, moirai, "
+                f"naive_baseline, statistical, deepar, patchtst, tft"
             )
 
 
@@ -2181,9 +2203,18 @@ stored in separate subdirectories for comparison.
         skip_steps.add(4)
 
     # Set output directory
+    # Always create a unique timestamped RID subdirectory so that:
+    #   - repeated runs never clobber each other, and
+    #   - the artifacts root (e.g. trained_models/artifacts/ttm) is not polluted.
+    _now = datetime.now()
+    _ts_short = _now.strftime("%Y-%m-%d_%H:%M")
+    _ts_long = _now.strftime("%Y%m%d_%H%M%S")
+    _pid = os.getpid()
+    _run_subdir = f"{_ts_short}_RID{_ts_long}_{_pid}_holdout_workflow"
     if args.output_dir is None:
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H:%M")
-        args.output_dir = f"./trained_models/artifacts/_tsfm_testing/{timestamp}_{args.model_type}_holdout_workflow"
+        args.output_dir = f"./trained_models/artifacts/_tsfm_testing/{_run_subdir}"
+    else:
+        args.output_dir = str(Path(args.output_dir) / _run_subdir)
 
     logger.info("=" * 80)
     logger.info("GENERIC FORECASTER WORKFLOW DEMONSTRATION")

--- a/scripts/experiments/nocturnal_hypo_eval.py
+++ b/scripts/experiments/nocturnal_hypo_eval.py
@@ -47,6 +47,10 @@ from src.evaluation.nocturnal import (
     STEPS_PER_HOUR,
 )
 from src.evaluation.storage import write_nocturnal_results
+from src.experiments.nocturnal.grand_summary import (
+    bucket_from_covariates,
+    model_supports_past_covariates,
+)
 from src.models import create_model_and_config
 from src.utils import get_git_commit_hash, setup_file_logging, load_yaml_config
 
@@ -262,6 +266,21 @@ def main():
     }
     model_kwargs.pop("model_type", None)
 
+    # Early check: covariate columns were passed for a model that cannot use them.
+    # Fail immediately before loading weights to prevent silent data leakage bugs.
+    requested_covariates = config_dict.get("covariate_cols") or args.covariate_cols
+    if requested_covariates and not model_supports_past_covariates(args.model):
+        logger.error(
+            "%s does not support past covariates but --covariate-cols %s was "
+            "passed. Remove --covariate-cols or use a model that accepts "
+            "past covariates (e.g., chronos2, tft, tide).",
+            args.model,
+            requested_covariates,
+        )
+        raise ValueError(
+            f"{args.model} does not support past covariates: {requested_covariates}"
+        )
+
     # Initialize model
     logger.info(f"\n--- Initializing {args.model.upper()} ---")
     model, config = create_model_and_config(
@@ -278,8 +297,8 @@ def main():
         )
         raise ValueError("Model does not support probabilistic forecasting")
 
-    context_length = config.context_length
-    forecast_length = config.forecast_length
+    context_length = args.context_length
+    forecast_length = args.forecast_length
     mode = "Fine-tuned" if args.checkpoint else "Zero-shot"
 
     # Setup output directory and file logging BEFORE logging config,
@@ -409,6 +428,9 @@ def main():
         "dataset": args.dataset,
         "timestamp": datetime.now().isoformat(),
         "config": resolved_config,
+        "cov_bucket": bucket_from_covariates(
+            mode.lower().replace("-", ""), covariate_cols
+        ),
     }
     written = write_nocturnal_results(results, output_path, tier_metadata)
     for tier_name, tier_path in written.items():


### PR DESCRIPTION
## Summary
This finishes a focused, public-safe extraction from `feat/autogluon-baselines` by landing only portable script improvements.

### Included
- Extend holdout workflow loader support for AutoGluon model families in `scripts/examples/example_holdout_generic_workflow.py`.
- Ensure holdout workflow output always goes to a unique RID subdirectory to avoid overwrite/pollution.
- Add early covariate-compatibility validation in `scripts/experiments/nocturnal_hypo_eval.py`.
- Record `cov_bucket` metadata in nocturnal results.

### Explicitly excluded
- Local-path rerun scripts and run manifests (`rerun_*`).
- Generated artifacts / result dumps.
- Broad branch-wide merges.

## Validation
- `PYTHONPATH=. .noctprob-venv/bin/python scripts/experiments/nocturnal_hypo_eval.py --help`
- `PYTHONPATH=. .noctprob-venv/bin/python scripts/examples/example_holdout_generic_workflow.py --help`
- `.noctprob-venv/bin/python -m pytest -q tests/experiments/test_nocturnal_summarizer.py` (13 passed)

## Notes
- This PR is intentionally small and independent of the older mixed local WIP state.