### PR TITLE
P1-15 Phase 3: wire data holdout and evaluation schema lanes

### DIFF
--- a/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
+++ b/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
@@ -91,7 +91,7 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 
 ## Immediate next slice (what to implement next)
 
-1. 🔄 Expand pilot coverage beyond model config load (workflow request + data holdout schema lanes wired; evaluation schema contract next).
+1. ✅ Expand pilot coverage beyond model config load (workflow request + data holdout + evaluation feature-override schema lanes wired).
 2. ✅ Add fixture-backed regression tests against active `configs/models/tsmixer/*.yaml` profiles.
 3. Draft the Phase 3 migration table (model/data/eval ownership and target schema classes).
 
@@ -107,4 +107,4 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 
 1. ✅ Data holdout schema adapter (`configs/data/holdout*` files) with parity checks against `HoldoutConfig`.
 2. ✅ Workflow request schema for `ForecastingWorkflowRequest`/CLI normalization.
-3. Evaluation override schema for the subset read in `evaluation.py` and `pipeline.py`.
+3. ✅ Evaluation override schema for the subset read in `evaluation.py` and `pipeline.py`.

--- a/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
+++ b/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
@@ -91,7 +91,7 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 
 ## Immediate next slice (what to implement next)
 
-1. 🔄 Expand pilot coverage beyond model config load (workflow request schema wired; data/eval schema contracts next).
+1. 🔄 Expand pilot coverage beyond model config load (workflow request + data holdout schema lanes wired; evaluation schema contract next).
 2. ✅ Add fixture-backed regression tests against active `configs/models/tsmixer/*.yaml` profiles.
 3. Draft the Phase 3 migration table (model/data/eval ownership and target schema classes).
 
@@ -100,11 +100,11 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 | Domain | Current runtime surface | Current contract path | Target schema module | Migration owner |
 |---|---|---|---|---|
 | Model config (pilot complete) | `src/workflows/forecasting/modeling.py` (`load_model_config_from_yaml`, `ModelFactory.create_model`) | `src/config/schemas/model_configs.py` route registry + adapter | `src/config/schemas/model_configs.py` | Forecasting workflow |
-| Data holdout config | `src/data/versioning/dataset_registry.py` + `src/data/versioning/holdout_manager.py` | Dataclass validation in `src/data/versioning/holdout_config.py` | `src/config/schemas/data_configs.py` (planned) | Data/versioning |
-| Workflow/evaluation request config | `src/workflows/forecasting/pipeline.py` (`ForecastingWorkflowRequest`, `argparse` in `run_with_args`) + `src/workflows/forecasting/evaluation.py` | Ad-hoc dict/arg parsing (`model_config_overrides`, CLI args) | `src/config/schemas/workflow_configs.py` (planned) | Forecasting workflow |
+| Data holdout config | `src/data/versioning/dataset_registry.py` + `src/data/versioning/holdout_manager.py` | Dataclass validation in `src/data/versioning/holdout_config.py` | `src/config/schemas/data_configs.py` (active) | Data/versioning |
+| Workflow/evaluation request config | `src/workflows/forecasting/pipeline.py` (`ForecastingWorkflowRequest`, `argparse` in `run_with_args`) + `src/workflows/forecasting/evaluation.py` | Ad-hoc dict/arg parsing (`model_config_overrides`, CLI args) | `src/config/schemas/workflow_configs.py` (active for request lane) | Forecasting workflow |
 
 ### Phase 3 rollout order
 
-1. Data holdout schema adapter (`configs/data/holdout*` files) with parity checks against `HoldoutConfig`.
-2. Workflow request schema for `ForecastingWorkflowRequest`/CLI normalization.
+1. ✅ Data holdout schema adapter (`configs/data/holdout*` files) with parity checks against `HoldoutConfig`.
+2. ✅ Workflow request schema for `ForecastingWorkflowRequest`/CLI normalization.
 3. Evaluation override schema for the subset read in `evaluation.py` and `pipeline.py`.

--- a/docs/architecture/workflow-configs-schema-guide.md
+++ b/docs/architecture/workflow-configs-schema-guide.md
@@ -1,0 +1,89 @@
+# Workflow Config Schemas (`src/config/schemas/workflow_configs.py`)
+
+This module defines the schema boundary for forecasting workflow request inputs and
+for model feature-selection overrides consumed by training/evaluation.
+
+## Why this module exists
+
+Before this schema lane, workflow inputs were accepted as loose dict/namespace
+values and feature overrides were read ad-hoc from model config dictionaries.
+
+`workflow_configs.py` centralizes those contracts so:
+
+- request payload validation is explicit and early,
+- invalid values fail with actionable field-level messages,
+- feature selection keys are validated consistently across pipeline and evaluation.
+
+## Core classes
+
+### `ForecastingWorkflowRequestSchema`
+
+Purpose:
+
+- validates the request surface used by forecasting workflow entrypoints.
+
+Key fields:
+
+- `model_type`: non-empty model identifier.
+- `datasets`: non-empty list of dataset names.
+- `config_dir`, `output_dir`: workflow paths.
+- `skip_training`, `skip_steps`, `epochs`, `batch_size`.
+- `model_config_path`: accepts both `model_config_path` and legacy `model_config`
+  input keys via aliasing.
+
+Validation behavior:
+
+- `skip_steps` must contain only step numbers `1..7`.
+- numeric fields (`epochs`, `batch_size`) must be positive when provided.
+
+Usage in repo:
+
+- `src/workflows/forecasting/pipeline.py` (`run_with_args`) validates incoming
+  args via `validate_forecasting_workflow_request(...)` before workflow execution.
+
+### `EvaluationFeatureOverrideEnvelope`
+
+Purpose:
+
+- validates only feature-selection keys (`input_features`, `target_features`)
+  while permitting other model-config keys to pass through untouched.
+
+Why `extra="allow"`:
+
+- model configs contain many non-feature keys (architecture/training/runtime).
+- this schema is intentionally narrow: it asserts feature list types while not
+  constraining the entire model-config payload.
+
+Usage in repo:
+
+- consumed by `get_model_feature_override_columns(...)`.
+- used by:
+  - `src/workflows/forecasting/pipeline.py` (step 5/7 training-column filtering),
+  - `src/workflows/forecasting/evaluation.py` (`_generate_forecasts` filtering).
+
+## Helper functions
+
+### `validate_forecasting_workflow_request(payload)`
+
+- validates request payload against `ForecastingWorkflowRequestSchema`.
+- raises `ValueError` with field-path diagnostics on invalid input.
+
+### `get_model_feature_override_columns(model_config_overrides)`
+
+- validates feature override keys through `EvaluationFeatureOverrideEnvelope`.
+- returns:
+  - `None` when no feature override keys are provided,
+  - combined feature list `[...input_features, ...target_features]` otherwise.
+- raises `ValueError` on invalid types (e.g., string instead of list for
+  `input_features`).
+
+## Design pattern in the repository
+
+`workflow_configs.py` follows the same split used by other schema modules:
+
+1. **Schema layer** (`src/config/schemas/*`) validates external/runtime payloads.
+2. **Workflow/model runtime layer** (`src/workflows/*`, `src/models/*`) performs
+   execution with normalized validated values.
+
+This keeps strict validation at boundaries without relocating model-owned runtime
+config classes from `src/models/*/config.py`.

--- a/docs/architecture/workflow-configs-schema-guide.md
+++ b/docs/architecture/workflow-configs-schema-guide.md
@@ -28,8 +28,15 @@ Key fields:
 - `datasets`: non-empty list of dataset names.
 - `config_dir`, `output_dir`: workflow paths.
 - `skip_training`, `skip_steps`, `epochs`, `batch_size`.
-- `model_config_path`: accepts both `model_config_path` and legacy `model_config`
-  input keys via aliasing.
+- `model_config_path`: path to the model YAML override file.
+
+How this connects to CLI:
+
+- The CLI flag is still `--model-config` in the workflow parser.
+- `pipeline.py` maps that CLI value into the schema field `model_config_path`
+  before validation.
+- We keep one schema field name (`model_config_path`) as the canonical internal
+  contract.
 
 Validation behavior:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,8 @@ Documentation is currently under construction.
 
 [Repository Design Handbook](architecture/repository-design-handbook.md)
 
+[Workflow Config Schemas](architecture/workflow-configs-schema-guide.md)
+
 ## MkDocs
 This documentation is made with [mkdocs.org](https://www.mkdocs.org).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Home: index.md
   - Architecture:
       - Repository Design Handbook: architecture/repository-design-handbook.md
+      - Workflow Config Schemas: architecture/workflow-configs-schema-guide.md
   - User Guide:
       - Usage: user-guide/usage.md
       - Getting Started: user-guide/getting-started.md

--- a/src/config/schemas/__init__.py
+++ b/src/config/schemas/__init__.py
@@ -1,5 +1,10 @@
 """Exports for config schema models and validation helpers."""
 
+from .data_configs import (
+    HoldoutConfigSchema,
+    build_holdout_runtime_config,
+    load_holdout_runtime_config_from_yaml,
+)
 from .loader import load_yaml_as_schema
 from .model_configs import (
     TSMixerModelConfigSchema,
@@ -14,12 +19,15 @@ from .workflow_configs import (
 )
 
 __all__ = [
+    "HoldoutConfigSchema",
     "TSMixerModelConfigSchema",
+    "build_holdout_runtime_config",
     "build_model_runtime_config",
     "build_tsmixer_runtime_config",
     "get_registered_model_config_types",
     "get_model_config_schema",
     "ForecastingWorkflowRequestSchema",
+    "load_holdout_runtime_config_from_yaml",
     "validate_forecasting_workflow_request",
     "load_yaml_as_schema",
 ]

--- a/src/config/schemas/__init__.py
+++ b/src/config/schemas/__init__.py
@@ -15,6 +15,7 @@ from .model_configs import (
 )
 from .workflow_configs import (
     ForecastingWorkflowRequestSchema,
+    get_model_feature_override_columns,
     validate_forecasting_workflow_request,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "get_registered_model_config_types",
     "get_model_config_schema",
     "ForecastingWorkflowRequestSchema",
+    "get_model_feature_override_columns",
     "load_holdout_runtime_config_from_yaml",
     "validate_forecasting_workflow_request",
     "load_yaml_as_schema",

--- a/src/config/schemas/data_configs.py
+++ b/src/config/schemas/data_configs.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import Field, ValidationError, model_validator
 
 from .base import BaseConfigSchema
 from .loader import load_yaml_as_schema
-
-if TYPE_CHECKING:
-    from src.data.versioning.holdout_config import HoldoutConfig
 
 
 class TemporalHoldoutConfigSchema(BaseConfigSchema):
@@ -66,7 +64,13 @@ def _format_validation_details(exc: ValidationError) -> str:
     return "\n".join(details)
 
 
-def build_holdout_runtime_config(config_data: dict) -> "HoldoutConfig":
+def _to_holdout_config(validated_payload: dict):
+    holdout_module = import_module("src.data.versioning.holdout_config")
+    holdout_cls = getattr(holdout_module, "HoldoutConfig")
+    return holdout_cls.from_dict(validated_payload)
+
+
+def build_holdout_runtime_config(config_data: dict):
     """Validate and adapt mapping payload to HoldoutConfig runtime object."""
     try:
         schema = HoldoutConfigSchema.model_validate(config_data)
@@ -76,14 +80,10 @@ def build_holdout_runtime_config(config_data: dict) -> "HoldoutConfig":
             f"{_format_validation_details(exc)}"
         ) from exc
 
-    from src.data.versioning.holdout_config import HoldoutConfig
-
-    return HoldoutConfig.from_dict(schema.model_dump(exclude_none=True))
+    return _to_holdout_config(schema.model_dump(exclude_none=True))
 
 
-def load_holdout_runtime_config_from_yaml(config_path: str | Path) -> "HoldoutConfig":
+def load_holdout_runtime_config_from_yaml(config_path: str | Path):
     """Load YAML holdout config using schema validation and runtime adapter."""
     validated = load_yaml_as_schema(config_path, HoldoutConfigSchema)
-    from src.data.versioning.holdout_config import HoldoutConfig
-
-    return HoldoutConfig.from_dict(validated.model_dump(exclude_none=True))
+    return _to_holdout_config(validated.model_dump(exclude_none=True))

--- a/src/config/schemas/data_configs.py
+++ b/src/config/schemas/data_configs.py
@@ -1,0 +1,89 @@
+"""Data/holdout config schemas and runtime adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Optional
+
+from pydantic import Field, ValidationError, model_validator
+
+from .base import BaseConfigSchema
+from .loader import load_yaml_as_schema
+
+if TYPE_CHECKING:
+    from src.data.versioning.holdout_config import HoldoutConfig
+
+
+class TemporalHoldoutConfigSchema(BaseConfigSchema):
+    """Schema contract for temporal holdout config section."""
+
+    holdout_percentage: float = Field(gt=0.0, lt=1.0)
+    min_train_samples: int = Field(gt=0)
+    min_holdout_samples: int = Field(gt=0)
+
+
+class PatientHoldoutConfigSchema(BaseConfigSchema):
+    """Schema contract for patient holdout config section."""
+
+    holdout_patients: list[str] = Field(default_factory=list)
+    holdout_percentage: Optional[float] = Field(default=None, gt=0.0, lt=1.0)
+    min_train_patients: int = Field(gt=0)
+    min_holdout_patients: int = Field(gt=0)
+    random_seed: int = Field(default=42)
+
+
+class HoldoutConfigSchema(BaseConfigSchema):
+    """Schema contract for full holdout configuration YAML."""
+
+    dataset_name: str = Field(min_length=1)
+    holdout_type: Literal["temporal", "patient_based", "hybrid"]
+    temporal_config: Optional[TemporalHoldoutConfigSchema] = Field(default=None)
+    patient_config: Optional[PatientHoldoutConfigSchema] = Field(default=None)
+    description: str = Field(default="")
+    created_date: Optional[str] = Field(default=None)
+    version: str = Field(default="1.0")
+
+    @model_validator(mode="after")
+    def _validate_holdout_type_requirements(self) -> "HoldoutConfigSchema":
+        if self.holdout_type == "temporal" and self.temporal_config is None:
+            raise ValueError("temporal_config required for holdout_type=temporal")
+        if self.holdout_type == "patient_based" and self.patient_config is None:
+            raise ValueError("patient_config required for holdout_type=patient_based")
+        if self.holdout_type == "hybrid":
+            if self.temporal_config is None or self.patient_config is None:
+                raise ValueError(
+                    "Both temporal_config and patient_config required for holdout_type=hybrid"
+                )
+        return self
+
+
+def _format_validation_details(exc: ValidationError) -> str:
+    details = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err.get("loc", ()))
+        msg = err.get("msg", "validation error")
+        details.append(f"  - {loc}: {msg}" if loc else f"  - {msg}")
+    return "\n".join(details)
+
+
+def build_holdout_runtime_config(config_data: dict) -> "HoldoutConfig":
+    """Validate and adapt mapping payload to HoldoutConfig runtime object."""
+    try:
+        schema = HoldoutConfigSchema.model_validate(config_data)
+    except ValidationError as exc:
+        raise ValueError(
+            "Invalid holdout config payload for HoldoutConfigSchema:\n"
+            f"{_format_validation_details(exc)}"
+        ) from exc
+
+    from src.data.versioning.holdout_config import HoldoutConfig
+
+    return HoldoutConfig.from_dict(schema.model_dump(exclude_none=True))
+
+
+def load_holdout_runtime_config_from_yaml(config_path: str | Path) -> "HoldoutConfig":
+    """Load YAML holdout config using schema validation and runtime adapter."""
+    validated = load_yaml_as_schema(config_path, HoldoutConfigSchema)
+    from src.data.versioning.holdout_config import HoldoutConfig
+
+    return HoldoutConfig.from_dict(validated.model_dump(exclude_none=True))

--- a/src/config/schemas/workflow_configs.py
+++ b/src/config/schemas/workflow_configs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import AliasChoices, ConfigDict, Field, ValidationError, field_validator
+from pydantic import ConfigDict, Field, ValidationError, field_validator
 
 from .base import BaseConfigSchema
 
@@ -20,11 +20,7 @@ class ForecastingWorkflowRequestSchema(BaseConfigSchema):
     skip_steps: list[int] = Field(default_factory=list)
     epochs: Optional[int] = Field(default=None, gt=0)
     batch_size: Optional[int] = Field(default=None, gt=0)
-    model_config_path: Optional[str] = Field(
-        default=None,
-        validation_alias=AliasChoices("model_config_path", "model_config"),
-        serialization_alias="model_config",
-    )
+    model_config_path: Optional[str] = Field(default=None)
 
     @field_validator("skip_steps")
     @classmethod

--- a/src/config/schemas/workflow_configs.py
+++ b/src/config/schemas/workflow_configs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import AliasChoices, Field, ValidationError, field_validator
+from pydantic import AliasChoices, ConfigDict, Field, ValidationError, field_validator
 
 from .base import BaseConfigSchema
 
@@ -37,6 +37,20 @@ class ForecastingWorkflowRequestSchema(BaseConfigSchema):
         return steps
 
 
+class EvaluationFeatureOverrideEnvelope(BaseConfigSchema):
+    """Envelope schema that validates feature override keys while allowing extras."""
+
+    model_config = ConfigDict(
+        extra="allow",
+        strict=True,
+        populate_by_name=True,
+        use_enum_values=True,
+        str_strip_whitespace=True,
+    )
+    input_features: Optional[list[str]] = Field(default=None)
+    target_features: Optional[list[str]] = Field(default=None)
+
+
 def _format_validation_details(exc: ValidationError) -> str:
     details = []
     for err in exc.errors():
@@ -57,3 +71,25 @@ def validate_forecasting_workflow_request(
             "Invalid forecasting workflow request payload:\n"
             f"{_format_validation_details(exc)}"
         ) from exc
+
+
+def get_model_feature_override_columns(
+    model_config_overrides: Optional[dict[str, Any]],
+) -> Optional[list[str]]:
+    """Validate and extract input/target feature columns from model overrides."""
+    if not model_config_overrides:
+        return None
+    try:
+        parsed = EvaluationFeatureOverrideEnvelope.model_validate(
+            model_config_overrides
+        )
+    except ValidationError as exc:
+        raise ValueError(
+            "Invalid feature override keys in model config payload:\n"
+            f"{_format_validation_details(exc)}"
+        ) from exc
+
+    input_features = parsed.input_features or []
+    target_features = parsed.target_features or []
+    feature_columns = list(input_features) + list(target_features)
+    return feature_columns or None

--- a/src/data/versioning/dataset_registry.py
+++ b/src/data/versioning/dataset_registry.py
@@ -15,7 +15,7 @@ from typing import Dict, Optional, Tuple, Union
 
 import pandas as pd
 
-from src.config.schemas import load_holdout_runtime_config_from_yaml
+from src.config.schemas.data_configs import load_holdout_runtime_config_from_yaml
 from src.data.diabetes_datasets.data_loader import get_loader
 from src.data.versioning.holdout_config import HoldoutConfig
 from src.data.versioning.holdout_manager import HoldoutManager

--- a/src/data/versioning/dataset_registry.py
+++ b/src/data/versioning/dataset_registry.py
@@ -15,10 +15,10 @@ from typing import Dict, Optional, Tuple, Union
 
 import pandas as pd
 
-from src.config.schemas.data_configs import load_holdout_runtime_config_from_yaml
-from src.data.diabetes_datasets.data_loader import get_loader
-from src.data.versioning.holdout_config import HoldoutConfig
-from src.data.versioning.holdout_manager import HoldoutManager
+from ...config.schemas.data_configs import load_holdout_runtime_config_from_yaml
+from ..diabetes_datasets.data_loader import get_loader
+from .holdout_config import HoldoutConfig
+from .holdout_manager import HoldoutManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/data/versioning/dataset_registry.py
+++ b/src/data/versioning/dataset_registry.py
@@ -15,6 +15,7 @@ from typing import Dict, Optional, Tuple, Union
 
 import pandas as pd
 
+from src.config.schemas import load_holdout_runtime_config_from_yaml
 from src.data.diabetes_datasets.data_loader import get_loader
 from src.data.versioning.holdout_config import HoldoutConfig
 from src.data.versioning.holdout_manager import HoldoutManager
@@ -74,7 +75,7 @@ class DatasetRegistry:
             return None
 
         try:
-            config = HoldoutConfig.load(config_path)
+            config = load_holdout_runtime_config_from_yaml(config_path)
             self._loaded_configs[dataset_name] = config
             return config
         except Exception as e:

--- a/src/workflows/forecasting/evaluation.py
+++ b/src/workflows/forecasting/evaluation.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from ...config.schemas import get_model_feature_override_columns
+from ...config.schemas.workflow_configs import get_model_feature_override_columns
 from ...data.versioning.dataset_registry import DatasetRegistry
 from ...evaluation.episode_builders import build_midnight_episodes
 

--- a/src/workflows/forecasting/evaluation.py
+++ b/src/workflows/forecasting/evaluation.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from ...config.schemas import get_model_feature_override_columns
 from ...data.versioning.dataset_registry import DatasetRegistry
 from ...evaluation.episode_builders import build_midnight_episodes
 
@@ -79,16 +80,9 @@ def _generate_forecasts(
         forecast_length = model.config.forecast_length
         registry = DatasetRegistry(holdout_config_dir=config_dir)
 
-        if model_config_overrides:
-            input_features = model_config_overrides.get("input_features") or []
-            target_features = model_config_overrides.get("target_features") or []
-            if input_features or target_features:
-                model_features = list(input_features) + list(target_features)
-                logger.info(f"  Using model config features: {model_features}")
-            else:
-                model_features = None
-        else:
-            model_features = None
+        model_features = get_model_feature_override_columns(model_config_overrides)
+        if model_features:
+            logger.info(f"  Using model config features: {model_features}")
 
         predictions_dir = Path(output_dir) / "predictions" / phase_name
         predictions_dir.mkdir(parents=True, exist_ok=True)

--- a/src/workflows/forecasting/pipeline.py
+++ b/src/workflows/forecasting/pipeline.py
@@ -22,7 +22,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
-from src.config.schemas import validate_forecasting_workflow_request
+from src.config.schemas import (
+    get_model_feature_override_columns,
+    validate_forecasting_workflow_request,
+)
 from src.data.versioning.dataset_registry import DatasetRegistry
 from src.data.preprocessing.dataset_combiner import (
     combine_datasets_for_training,
@@ -506,21 +509,19 @@ def step5_train_model(
     # Filter training data to only model config columns if specified
     # This ensures the preprocessor only learns scalers for the features we'll use at inference
     train_data_for_model = combined_data
-    if model_config_overrides:
-        # Guard against YAML null values converting to None
-        input_features = model_config_overrides.get("input_features") or []
-        target_features = model_config_overrides.get("target_features") or []
-        if input_features or target_features:
-            required_cols = ["p_num", "id", "datetime"]
-            model_cols = list(input_features) + list(target_features)
-            all_cols = [
-                col
-                for col in model_cols + required_cols
-                if col in combined_data.columns
-            ]
-            train_data_for_model = combined_data[all_cols].copy()
-            logger.info(f"Filtered training data to model config columns: {model_cols}")
-            logger.info(f"  Training data shape: {train_data_for_model.shape}")
+    model_feature_cols = get_model_feature_override_columns(model_config_overrides)
+    if model_feature_cols:
+        required_cols = ["p_num", "id", "datetime"]
+        all_cols = [
+            col
+            for col in model_feature_cols + required_cols
+            if col in combined_data.columns
+        ]
+        train_data_for_model = combined_data[all_cols].copy()
+        logger.info(
+            f"Filtered training data to model config columns: {model_feature_cols}"
+        )
+        logger.info(f"  Training data shape: {train_data_for_model.shape}")
 
     try:
         # Train the model (fit() is implemented by each model type)
@@ -686,19 +687,15 @@ def step7_resume_training(
 
     # Filter training data to same columns used in initial training
     train_data_for_model = combined_data
-    if model_config_overrides:
-        # Guard against YAML null values converting to None
-        input_features = model_config_overrides.get("input_features") or []
-        target_features = model_config_overrides.get("target_features") or []
-        if input_features or target_features:
-            required_cols = ["p_num", "id", "datetime"]
-            model_cols = list(input_features) + list(target_features)
-            all_cols = [
-                col
-                for col in model_cols + required_cols
-                if col in combined_data.columns
-            ]
-            train_data_for_model = combined_data[all_cols].copy()
+    model_feature_cols = get_model_feature_override_columns(model_config_overrides)
+    if model_feature_cols:
+        required_cols = ["p_num", "id", "datetime"]
+        all_cols = [
+            col
+            for col in model_feature_cols + required_cols
+            if col in combined_data.columns
+        ]
+        train_data_for_model = combined_data[all_cols].copy()
 
     try:
         # Continue training (fit() is implemented by child class)

--- a/src/workflows/forecasting/pipeline.py
+++ b/src/workflows/forecasting/pipeline.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
-from src.config.schemas import (
+from src.config.schemas.workflow_configs import (
     get_model_feature_override_columns,
     validate_forecasting_workflow_request,
 )
@@ -956,7 +956,7 @@ def run_with_args(args: argparse.Namespace) -> int:
             "skip_steps": args.skip_steps,
             "epochs": args.epochs,
             "batch_size": args.batch_size,
-            "model_config": args.model_config,
+            "model_config_path": args.model_config,
         }
     )
     args.model_type = validated_request.model_type

--- a/src/workflows/forecasting/pipeline.py
+++ b/src/workflows/forecasting/pipeline.py
@@ -22,28 +22,28 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
-from src.config.schemas.workflow_configs import (
+from ...config.schemas.workflow_configs import (
     get_model_feature_override_columns,
     validate_forecasting_workflow_request,
 )
-from src.data.versioning.dataset_registry import DatasetRegistry
-from src.data.preprocessing.dataset_combiner import (
+from ...data.versioning.dataset_registry import DatasetRegistry
+from ...data.preprocessing.dataset_combiner import (
     combine_datasets_for_training,
     print_dataset_column_table,
 )
-from src.workflows.forecasting.evaluation import (
+from .evaluation import (
     evaluate_and_plot as phase_evaluate_and_plot,
 )
-from src.workflows.forecasting.modeling import (
+from .modeling import (
     GenericModelConfig,
     ModelFactory,
     load_model_config_from_yaml as load_workflow_model_config_from_yaml,
 )
-from src.workflows.runtime.hardware import (
+from ..runtime.hardware import (
     clear_cuda_cache,
     get_gpu_info as runtime_get_gpu_info,
 )
-from src.workflows.runtime.manifest import (
+from ..runtime.manifest import (
     build_run_manifest,
     utc_now,
     write_run_manifest,

--- a/tests/data/versioning/test_holdout_config_schema_loader.py
+++ b/tests/data/versioning/test_holdout_config_schema_loader.py
@@ -1,0 +1,98 @@
+"""Tests for schema-validated holdout config loading and registry wiring."""
+
+from pathlib import Path
+
+import pytest
+
+from src.config.schemas import (
+    build_holdout_runtime_config,
+    load_holdout_runtime_config_from_yaml,
+)
+from src.data.versioning.dataset_registry import DatasetRegistry
+from src.data.versioning.holdout_config import HoldoutConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_holdout_yaml_schema_loader_matches_legacy_runtime_for_fixture() -> None:
+    fixture = REPO_ROOT / "configs" / "data" / "holdout_10pct" / "aleppo_2017.yaml"
+
+    legacy = HoldoutConfig.load(fixture)
+    schema_loaded = load_holdout_runtime_config_from_yaml(fixture)
+
+    assert schema_loaded.to_dict() == legacy.to_dict()
+
+
+def test_build_holdout_runtime_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        build_holdout_runtime_config(
+            {
+                "dataset_name": "demo",
+                "holdout_type": "hybrid",
+                "temporal_config": {
+                    "holdout_percentage": 0.1,
+                    "min_train_samples": 100,
+                    "min_holdout_samples": 20,
+                },
+                "patient_config": {
+                    "holdout_patients": [],
+                    "holdout_percentage": 0.2,
+                    "min_train_patients": 2,
+                    "min_holdout_patients": 1,
+                    "random_seed": 42,
+                },
+                "unexpected_root_key": True,
+            }
+        )
+
+    assert "unexpected_root_key" in str(exc_info.value)
+
+
+def test_build_holdout_runtime_config_requires_hybrid_sections() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        build_holdout_runtime_config(
+            {
+                "dataset_name": "demo",
+                "holdout_type": "hybrid",
+                "temporal_config": {
+                    "holdout_percentage": 0.1,
+                    "min_train_samples": 100,
+                    "min_holdout_samples": 20,
+                },
+            }
+        )
+
+    assert "patient_config" in str(exc_info.value)
+
+
+def test_dataset_registry_uses_schema_validation_for_holdout_configs(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "demo_dataset.yaml",
+        """
+dataset_name: demo_dataset
+holdout_type: hybrid
+temporal_config:
+  holdout_percentage: 0.1
+  min_train_samples: 100
+  min_holdout_samples: 20
+patient_config:
+  holdout_patients: []
+  holdout_percentage: 0.2
+  min_train_patients: 2
+  min_holdout_patients: 1
+  random_seed: 42
+unexpected_root_key: true
+""".strip(),
+    )
+
+    registry = DatasetRegistry(holdout_config_dir=tmp_path)
+    config = registry.get_holdout_config("demo_dataset")
+
+    assert config is None

--- a/tests/data/versioning/test_holdout_config_schema_loader.py
+++ b/tests/data/versioning/test_holdout_config_schema_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from src.config.schemas import (
+from src.config.schemas.data_configs import (
     build_holdout_runtime_config,
     load_holdout_runtime_config_from_yaml,
 )

--- a/tests/workflows/forecasting/test_workflow_request_schema.py
+++ b/tests/workflows/forecasting/test_workflow_request_schema.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.config.schemas import (
+from src.config.schemas.workflow_configs import (
     get_model_feature_override_columns,
     validate_forecasting_workflow_request,
 )
@@ -19,7 +19,7 @@ def test_forecasting_workflow_request_schema_valid_payload() -> None:
             "skip_steps": [4, 7],
             "epochs": 2,
             "batch_size": 32,
-            "model_config": "configs/models/tsmixer/00_iob_cob_smoke.yaml",
+            "model_config_path": "configs/models/tsmixer/00_iob_cob_smoke.yaml",
         }
     )
 

--- a/tests/workflows/forecasting/test_workflow_request_schema.py
+++ b/tests/workflows/forecasting/test_workflow_request_schema.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from src.config.schemas import validate_forecasting_workflow_request
+from src.config.schemas import (
+    get_model_feature_override_columns,
+    validate_forecasting_workflow_request,
+)
 
 
 def test_forecasting_workflow_request_schema_valid_payload() -> None:
@@ -51,3 +54,27 @@ def test_forecasting_workflow_request_schema_rejects_empty_datasets() -> None:
         )
 
     assert "datasets" in str(exc_info.value)
+
+
+def test_model_feature_override_columns_extracts_valid_lists() -> None:
+    columns = get_model_feature_override_columns(
+        {
+            "input_features": ["iob", "cob"],
+            "target_features": ["bg_mM"],
+            "batch_size": 32,
+        }
+    )
+
+    assert columns == ["iob", "cob", "bg_mM"]
+
+
+def test_model_feature_override_columns_rejects_invalid_types() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        get_model_feature_override_columns(
+            {
+                "input_features": "iob",
+                "target_features": ["bg_mM"],
+            }
+        )
+
+    assert "input_features" in str(exc_info.value)


### PR DESCRIPTION
## Summary
This PR advances **P1-15 Phase 3** by expanding schema coverage across data holdout and workflow evaluation surfaces.

### Included changes
- Added data holdout schemas + adapters in `src/config/schemas/data_configs.py`:
  - `HoldoutConfigSchema`
  - nested temporal/patient section schemas
  - YAML loader + runtime adapter helpers
- Wired dataset holdout loading through schema validation in `src/data/versioning/dataset_registry.py`.
- Added workflow feature-override validation/extraction helpers in `src/config/schemas/workflow_configs.py`.
- Wired validated feature override handling in:
  - `src/workflows/forecasting/pipeline.py`
  - `src/workflows/forecasting/evaluation.py`
- Exported new schema helpers in `src/config/schemas/__init__.py`.
- Added focused tests:
  - `tests/data/versioning/test_holdout_config_schema_loader.py`
  - `tests/workflows/forecasting/test_workflow_request_schema.py` (extended)
- Updated progress tracking in `agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md`.

## Validation
- `ruff check` on touched modules: ✅
- `pytest -q tests/data/versioning/test_holdout_config_schema_loader.py tests/workflows/forecasting/test_workflow_request_schema.py tests/workflows/forecasting/test_model_config_schema_loader.py tests/models/test_tsmixer_darts_wiring.py`: ✅ **23 passed**

## Scope notes
- Runtime model dataclasses remain model-owned in `src/models/*/config.py`.
- `src/config/schemas/*` remains the contract/validation layer.

## Next step after merge
- Start **Phase 4** consolidation:
  1. remove/centralize duplicate validation paths,
  2. generate JSON schema artifacts,
  3. document contributor workflow for schema evolution.