### PR TITLE
P1-15 Phase 4.2: generate JSON schema artifacts

### DIFF
--- a/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
+++ b/agent_notes/P1-15_PYDANTIC_CONFIG_SCHEMAS_EXECUTION_PLAN.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-20
 **Task ID:** `pydantic-config-schemas`
-**Status:** Phase 1-3 complete; Phase 4.1 consolidation in progress
+**Status:** Phase 1-3 complete; Phase 4.1-4.2 complete; Phase 4.3 pending
 
 ## What this task means (plain English)
 
@@ -94,7 +94,7 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 1. ✅ Phase 4.1 — consolidate duplicate holdout/model-config validation entrypoints:
    - migrated `src/experiments/nocturnal/holdout_split_analysis.py` from `HoldoutConfig.load(...)` to schema loader lane;
    - migrated workflow evaluation scripts that were still loading loose model YAML dicts (`src/workflows/evaluation/nocturnal_hypo_eval.py`, `src/workflows/evaluation/sliding_window_eval.py`, `src/workflows/evaluation/validate_predict_batch.py`) to shared model-config schema loader path.
-2. Phase 4.2 — generate JSON schema artifacts from active schema modules (`model_configs.py`, `data_configs.py`, `workflow_configs.py`) into docs-visible location.
+2. ✅ Phase 4.2 — generate JSON schema artifacts from active schema modules (`model_configs.py`, `data_configs.py`, `workflow_configs.py`) into docs-visible location (`docs/architecture/generated-config-schemas/`) via `python -m src.config.schemas.json_schema_artifacts`.
 3. Phase 4.3 — contributor doc pass: document canonical “add a schema + adapter” workflow and deprecate any stale validation guidance.
 4. Phase 4.x follow-on — execute model-family schema rollout backlog (table below) so all active model IDs use registry-backed schema adapters.
 
@@ -147,5 +147,5 @@ We do **not** need to preserve legacy functionality, we don't want to introduce 
 - [x] Branch housekeeping (remove stale local Phase 3 branch).
 - [x] Create dedicated Phase 4 branch.
 - [x] Implement validation-path consolidation changes.
-- [ ] Add JSON schema artifact generation.
+- [x] Add JSON schema artifact generation.
 - [ ] Final contributor documentation pass for schema evolution workflow.

--- a/docs/architecture/config-schema-artifacts.md
+++ b/docs/architecture/config-schema-artifacts.md
@@ -1,7 +1,54 @@
 # Config JSON Schema Artifacts
 
-Pydantic schema artifacts for active config lanes are generated into
-[`docs/architecture/generated-config-schemas/`](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas).
+This page explains why we generate JSON schema files from our Pydantic config
+schemas, and how contributors should use them.
+
+## Why this exists
+
+Our runtime reads YAML config files for model training/evaluation workflows.
+Those YAML files are validated by Pydantic schema classes in
+`src/config/schemas/`.
+
+The generated JSON schema artifacts are a **documentation and contract output**
+for those same schema classes:
+
+- they show exactly which fields are allowed,
+- they show required vs optional fields,
+- they show types and bounds (e.g., `gt=0`, enums, list types),
+- they make config contract changes visible in PR diffs.
+
+In short: these files let someone understand the config contract without reading
+all Python implementation details.
+
+## Why this is useful for an inexperienced developer
+
+If you're new to the repo, this is the fastest way to answer:
+
+- "What keys can I put in this YAML?"
+- "Which fields are required?"
+- "What value types/ranges are valid?"
+- "Did this PR change the config contract?"
+
+Instead of inferring behavior from scattered loader code, you can inspect one
+schema artifact and get an explicit answer.
+
+## Why this is a good practice
+
+Generating artifacts from source-of-truth schemas gives us:
+
+1. **Single source of truth**: validation logic and docs stay aligned.
+2. **Reviewability**: config contract changes are explicit in code review.
+3. **Tool interoperability**: JSON Schema can be consumed by editors, validators,
+   and external tooling.
+4. **Safer evolution**: schema changes are intentional and easy to audit.
+
+## What this does *not* do
+
+- It does not replace runtime validation.
+- It does not validate files by itself.
+- It does not imply every model family is fully migrated yet.
+
+It is a generated view of the schema lanes that are currently active.
 
 ## Regeneration command
 
@@ -11,13 +58,25 @@ Run from repository root:
 python -m src.config.schemas.json_schema_artifacts
 ```
 
-This writes:
+This command writes JSON schema files into
+[`docs/architecture/generated-config-schemas/`](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas):
 
 - `model_configs.tsmixer.schema.json`
 - `data_configs.holdout.schema.json`
 - `workflow_configs.forecasting_request.schema.json`
 - `workflow_configs.feature_override_envelope.schema.json`
 - `manifest.json`
+
+## When to regenerate
+
+Regenerate and commit these artifacts whenever you change any schema in:
+
+- `src/config/schemas/model_configs.py`
+- `src/config/schemas/data_configs.py`
+- `src/config/schemas/workflow_configs.py`
+
+If the schema changes but artifacts do not, reviewers lose visibility into the
+contract delta.
 
 ## Artifact index
 

--- a/docs/architecture/config-schema-artifacts.md
+++ b/docs/architecture/config-schema-artifacts.md
@@ -1,0 +1,28 @@
+# Config JSON Schema Artifacts
+
+Pydantic schema artifacts for active config lanes are generated into
+[`docs/architecture/generated-config-schemas/`](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas).
+
+## Regeneration command
+
+Run from repository root:
+
+```bash
+python -m src.config.schemas.json_schema_artifacts
+```
+
+This writes:
+
+- `model_configs.tsmixer.schema.json`
+- `data_configs.holdout.schema.json`
+- `workflow_configs.forecasting_request.schema.json`
+- `workflow_configs.feature_override_envelope.schema.json`
+- `manifest.json`
+
+## Artifact index
+
+- [manifest.json](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas/manifest.json)
+- [model_configs.tsmixer.schema.json](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas/model_configs.tsmixer.schema.json)
+- [data_configs.holdout.schema.json](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas/data_configs.holdout.schema.json)
+- [workflow_configs.forecasting_request.schema.json](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas/workflow_configs.forecasting_request.schema.json)
+- [workflow_configs.feature_override_envelope.schema.json](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas/workflow_configs.feature_override_envelope.schema.json)

--- a/docs/architecture/generated-config-schemas/data_configs.holdout.schema.json
+++ b/docs/architecture/generated-config-schemas/data_configs.holdout.schema.json
@@ -1,0 +1,149 @@
+{
+  "$defs": {
+    "PatientHoldoutConfigSchema": {
+      "additionalProperties": false,
+      "description": "Schema contract for patient holdout config section.",
+      "properties": {
+        "holdout_patients": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Holdout Patients",
+          "type": "array"
+        },
+        "holdout_percentage": {
+          "anyOf": [
+            {
+              "exclusiveMaximum": 1.0,
+              "exclusiveMinimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Holdout Percentage"
+        },
+        "min_holdout_patients": {
+          "exclusiveMinimum": 0,
+          "title": "Min Holdout Patients",
+          "type": "integer"
+        },
+        "min_train_patients": {
+          "exclusiveMinimum": 0,
+          "title": "Min Train Patients",
+          "type": "integer"
+        },
+        "random_seed": {
+          "default": 42,
+          "title": "Random Seed",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min_train_patients",
+        "min_holdout_patients"
+      ],
+      "title": "PatientHoldoutConfigSchema",
+      "type": "object"
+    },
+    "TemporalHoldoutConfigSchema": {
+      "additionalProperties": false,
+      "description": "Schema contract for temporal holdout config section.",
+      "properties": {
+        "holdout_percentage": {
+          "exclusiveMaximum": 1.0,
+          "exclusiveMinimum": 0.0,
+          "title": "Holdout Percentage",
+          "type": "number"
+        },
+        "min_holdout_samples": {
+          "exclusiveMinimum": 0,
+          "title": "Min Holdout Samples",
+          "type": "integer"
+        },
+        "min_train_samples": {
+          "exclusiveMinimum": 0,
+          "title": "Min Train Samples",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "holdout_percentage",
+        "min_train_samples",
+        "min_holdout_samples"
+      ],
+      "title": "TemporalHoldoutConfigSchema",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Schema contract for full holdout configuration YAML.",
+  "properties": {
+    "created_date": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Created Date"
+    },
+    "dataset_name": {
+      "minLength": 1,
+      "title": "Dataset Name",
+      "type": "string"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "holdout_type": {
+      "enum": [
+        "temporal",
+        "patient_based",
+        "hybrid"
+      ],
+      "title": "Holdout Type",
+      "type": "string"
+    },
+    "patient_config": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PatientHoldoutConfigSchema"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "temporal_config": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TemporalHoldoutConfigSchema"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "version": {
+      "default": "1.0",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "dataset_name",
+    "holdout_type"
+  ],
+  "title": "HoldoutConfigSchema",
+  "type": "object"
+}

--- a/docs/architecture/generated-config-schemas/manifest.json
+++ b/docs/architecture/generated-config-schemas/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemas": [
+    {
+      "file": "model_configs.tsmixer.schema.json",
+      "source_symbol": "src.config.schemas.model_configs.TSMixerModelConfigSchema"
+    },
+    {
+      "file": "data_configs.holdout.schema.json",
+      "source_symbol": "src.config.schemas.data_configs.HoldoutConfigSchema"
+    },
+    {
+      "file": "workflow_configs.forecasting_request.schema.json",
+      "source_symbol": "src.config.schemas.workflow_configs.ForecastingWorkflowRequestSchema"
+    },
+    {
+      "file": "workflow_configs.feature_override_envelope.schema.json",
+      "source_symbol": "src.config.schemas.workflow_configs.EvaluationFeatureOverrideEnvelope"
+    }
+  ]
+}

--- a/docs/architecture/generated-config-schemas/model_configs.tsmixer.schema.json
+++ b/docs/architecture/generated-config-schemas/model_configs.tsmixer.schema.json
@@ -1,0 +1,187 @@
+{
+  "additionalProperties": false,
+  "description": "Schema contract for TSMixer model YAML configs.",
+  "properties": {
+    "activation": {
+      "default": "ReLU",
+      "title": "Activation",
+      "type": "string"
+    },
+    "batch_size": {
+      "default": 32,
+      "exclusiveMinimum": 0,
+      "title": "Batch Size",
+      "type": "integer"
+    },
+    "context_length": {
+      "default": 512,
+      "exclusiveMinimum": 0,
+      "title": "Context Length",
+      "type": "integer"
+    },
+    "covariate_cols": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Covariate Cols",
+      "type": "array"
+    },
+    "dropout": {
+      "default": 0.1,
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Dropout",
+      "type": "number"
+    },
+    "ff_size": {
+      "default": 64,
+      "exclusiveMinimum": 0,
+      "title": "Ff Size",
+      "type": "integer"
+    },
+    "forecast_length": {
+      "default": 96,
+      "exclusiveMinimum": 0,
+      "title": "Forecast Length",
+      "type": "integer"
+    },
+    "fp16": {
+      "default": true,
+      "title": "Fp16",
+      "type": "boolean"
+    },
+    "freeze_backbone": {
+      "default": false,
+      "title": "Freeze Backbone",
+      "type": "boolean"
+    },
+    "hidden_size": {
+      "default": 64,
+      "exclusiveMinimum": 0,
+      "title": "Hidden Size",
+      "type": "integer"
+    },
+    "imputation_threshold_mins": {
+      "default": 45,
+      "exclusiveMinimum": 0,
+      "title": "Imputation Threshold Mins",
+      "type": "integer"
+    },
+    "interval_mins": {
+      "default": 5,
+      "exclusiveMinimum": 0,
+      "title": "Interval Mins",
+      "type": "integer"
+    },
+    "learning_rate": {
+      "default": 0.001,
+      "exclusiveMinimum": 0.0,
+      "title": "Learning Rate",
+      "type": "number"
+    },
+    "min_segment_length": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Min Segment Length"
+    },
+    "model_path": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Path"
+    },
+    "model_type": {
+      "default": "tsmixer",
+      "title": "Model Type",
+      "type": "string"
+    },
+    "norm_type": {
+      "default": "LayerNorm",
+      "title": "Norm Type",
+      "type": "string"
+    },
+    "normalize_before": {
+      "default": false,
+      "title": "Normalize Before",
+      "type": "boolean"
+    },
+    "num_blocks": {
+      "default": 2,
+      "exclusiveMinimum": 0,
+      "title": "Num Blocks",
+      "type": "integer"
+    },
+    "num_epochs": {
+      "default": 10,
+      "exclusiveMinimum": 0,
+      "title": "Num Epochs",
+      "type": "integer"
+    },
+    "patient_col": {
+      "default": "p_num",
+      "title": "Patient Col",
+      "type": "string"
+    },
+    "quantile_levels": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Quantile Levels"
+    },
+    "random_state": {
+      "default": 42,
+      "title": "Random State",
+      "type": "integer"
+    },
+    "target_col": {
+      "default": "bg_mM",
+      "title": "Target Col",
+      "type": "string"
+    },
+    "time_col": {
+      "default": "datetime",
+      "title": "Time Col",
+      "type": "string"
+    },
+    "training_mode": {
+      "default": "from_scratch",
+      "title": "Training Mode",
+      "type": "string"
+    },
+    "use_cpu": {
+      "default": false,
+      "title": "Use Cpu",
+      "type": "boolean"
+    },
+    "use_static_covariates": {
+      "default": false,
+      "title": "Use Static Covariates",
+      "type": "boolean"
+    }
+  },
+  "title": "TSMixerModelConfigSchema",
+  "type": "object"
+}

--- a/docs/architecture/generated-config-schemas/workflow_configs.feature_override_envelope.schema.json
+++ b/docs/architecture/generated-config-schemas/workflow_configs.feature_override_envelope.schema.json
@@ -1,0 +1,38 @@
+{
+  "additionalProperties": true,
+  "description": "Envelope schema that validates feature override keys while allowing extras.",
+  "properties": {
+    "input_features": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Input Features"
+    },
+    "target_features": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target Features"
+    }
+  },
+  "title": "EvaluationFeatureOverrideEnvelope",
+  "type": "object"
+}

--- a/docs/architecture/generated-config-schemas/workflow_configs.forecasting_request.schema.json
+++ b/docs/architecture/generated-config-schemas/workflow_configs.forecasting_request.schema.json
@@ -1,0 +1,93 @@
+{
+  "additionalProperties": false,
+  "description": "Validated request contract for forecasting workflow entrypoints.",
+  "properties": {
+    "batch_size": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Batch Size"
+    },
+    "config_dir": {
+      "default": "configs/data/holdout_10pct",
+      "minLength": 1,
+      "title": "Config Dir",
+      "type": "string"
+    },
+    "datasets": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Datasets",
+      "type": "array"
+    },
+    "epochs": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Epochs"
+    },
+    "model_config_path": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Config Path"
+    },
+    "model_type": {
+      "minLength": 1,
+      "title": "Model Type",
+      "type": "string"
+    },
+    "output_dir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Output Dir"
+    },
+    "skip_steps": {
+      "items": {
+        "type": "integer"
+      },
+      "title": "Skip Steps",
+      "type": "array"
+    },
+    "skip_training": {
+      "default": false,
+      "title": "Skip Training",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "model_type",
+    "datasets"
+  ],
+  "title": "ForecastingWorkflowRequestSchema",
+  "type": "object"
+}

--- a/docs/architecture/workflow-configs-schema-guide.md
+++ b/docs/architecture/workflow-configs-schema-guide.md
@@ -94,3 +94,16 @@ Usage in repo:
 
 This keeps strict validation at boundaries without relocating model-owned runtime
 config classes from `src/models/*/config.py`.
+
+## JSON schema artifact tie-in
+
+The schema classes documented here are also exported as JSON schema artifacts in
+[`docs/architecture/generated-config-schemas/`](/data/home/cjrisi/nocturnal-hypo-gly-prob-forecast/docs/architecture/generated-config-schemas)
+via:
+
+```bash
+python -m src.config.schemas.json_schema_artifacts
+```
+
+This keeps human-readable architecture docs and machine-readable schema contracts
+in sync during review.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ Documentation is currently under construction.
 
 [Workflow Config Schemas](architecture/workflow-configs-schema-guide.md)
 
+[Config Schema Artifacts](architecture/config-schema-artifacts.md)
+
 ## MkDocs
 This documentation is made with [mkdocs.org](https://www.mkdocs.org).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Architecture:
       - Repository Design Handbook: architecture/repository-design-handbook.md
       - Workflow Config Schemas: architecture/workflow-configs-schema-guide.md
+      - Config Schema Artifacts: architecture/config-schema-artifacts.md
   - User Guide:
       - Usage: user-guide/usage.md
       - Getting Started: user-guide/getting-started.md

--- a/src/config/schemas/json_schema_artifacts.py
+++ b/src/config/schemas/json_schema_artifacts.py
@@ -1,0 +1,96 @@
+"""Generate JSON schema artifacts from active config schema modules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from .base import BaseConfigSchema
+from .data_configs import HoldoutConfigSchema
+from .model_configs import TSMixerModelConfigSchema
+from .workflow_configs import (
+    EvaluationFeatureOverrideEnvelope,
+    ForecastingWorkflowRequestSchema,
+)
+
+
+class SchemaArtifactSpec(NamedTuple):
+    """One schema artifact export target."""
+
+    filename: str
+    schema_type: type[BaseConfigSchema]
+    source_symbol: str
+
+
+SCHEMA_ARTIFACT_SPECS: tuple[SchemaArtifactSpec, ...] = (
+    SchemaArtifactSpec(
+        filename="model_configs.tsmixer.schema.json",
+        schema_type=TSMixerModelConfigSchema,
+        source_symbol="src.config.schemas.model_configs.TSMixerModelConfigSchema",
+    ),
+    SchemaArtifactSpec(
+        filename="data_configs.holdout.schema.json",
+        schema_type=HoldoutConfigSchema,
+        source_symbol="src.config.schemas.data_configs.HoldoutConfigSchema",
+    ),
+    SchemaArtifactSpec(
+        filename="workflow_configs.forecasting_request.schema.json",
+        schema_type=ForecastingWorkflowRequestSchema,
+        source_symbol="src.config.schemas.workflow_configs.ForecastingWorkflowRequestSchema",
+    ),
+    SchemaArtifactSpec(
+        filename="workflow_configs.feature_override_envelope.schema.json",
+        schema_type=EvaluationFeatureOverrideEnvelope,
+        source_symbol="src.config.schemas.workflow_configs.EvaluationFeatureOverrideEnvelope",
+    ),
+)
+
+
+def get_default_schema_artifact_dir() -> Path:
+    """Return canonical docs-visible output directory for generated schemas."""
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "docs" / "architecture" / "generated-config-schemas"
+
+
+def _serialize_schema(schema_payload: dict[str, Any]) -> str:
+    return json.dumps(schema_payload, indent=2, sort_keys=True) + "\n"
+
+
+def generate_json_schema_artifacts(output_dir: Path | str) -> list[Path]:
+    """Write configured JSON schema artifacts and return written paths."""
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written_paths: list[Path] = []
+    manifest_items: list[dict[str, str]] = []
+
+    for spec in SCHEMA_ARTIFACT_SPECS:
+        payload = spec.schema_type.model_json_schema()
+        out_path = out_dir / spec.filename
+        out_path.write_text(_serialize_schema(payload))
+        written_paths.append(out_path)
+        manifest_items.append(
+            {
+                "file": spec.filename,
+                "source_symbol": spec.source_symbol,
+            }
+        )
+
+    manifest_payload = {"schemas": manifest_items}
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(_serialize_schema(manifest_payload))
+    written_paths.append(manifest_path)
+    return written_paths
+
+
+def main() -> int:
+    """CLI entrypoint for schema artifact generation."""
+    out_dir = get_default_schema_artifact_dir()
+    generated = generate_json_schema_artifacts(out_dir)
+    print(f"Wrote {len(generated)} schema artifact files to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/workflows/forecasting/test_config_schema_artifact_generation.py
+++ b/tests/workflows/forecasting/test_config_schema_artifact_generation.py
@@ -1,0 +1,27 @@
+"""Tests for JSON schema artifact generation."""
+
+from __future__ import annotations
+
+import json
+
+from src.config.schemas.json_schema_artifacts import (
+    SCHEMA_ARTIFACT_SPECS,
+    generate_json_schema_artifacts,
+)
+
+
+def test_generate_json_schema_artifacts_writes_expected_files(tmp_path) -> None:
+    written = generate_json_schema_artifacts(tmp_path)
+
+    expected_filenames = {spec.filename for spec in SCHEMA_ARTIFACT_SPECS}
+    expected_filenames.add("manifest.json")
+
+    assert {path.name for path in written} == expected_filenames
+    for filename in expected_filenames:
+        artifact_path = tmp_path / filename
+        assert artifact_path.exists()
+        json.loads(artifact_path.read_text())
+
+    manifest_payload = json.loads((tmp_path / "manifest.json").read_text())
+    manifest_files = [entry["file"] for entry in manifest_payload["schemas"]]
+    assert manifest_files == [spec.filename for spec in SCHEMA_ARTIFACT_SPECS]


### PR DESCRIPTION
## Summary
- add a code-backed JSON schema artifact generator at `src/config/schemas/json_schema_artifacts.py`
- generate docs-visible schema artifacts under `docs/architecture/generated-config-schemas/`
- add architecture docs page for regeneration + artifact index and wire MkDocs navigation
- mark Phase 4.2 complete in the P1-15 execution plan
- add focused test coverage for schema artifact generation

## Validation
- `ruff check src/config/schemas/json_schema_artifacts.py src/config/schemas/__init__.py tests/workflows/forecasting/test_config_schema_artifact_generation.py src/experiments/nocturnal/holdout_split_analysis.py src/workflows/evaluation/nocturnal_hypo_eval.py src/workflows/evaluation/sliding_window_eval.py src/workflows/evaluation/validate_predict_batch.py src/data/utils/__init__.py src/evaluation/metrics/__init__.py src/utils/__init__.py`
- `pytest -q tests/workflows/forecasting/test_config_schema_artifact_generation.py tests/workflows/forecasting/test_model_config_schema_loader.py tests/workflows/forecasting/test_workflow_request_schema.py tests/data/versioning/test_holdout_config_schema_loader.py tests/evaluation/test_forecast_prediction_validation.py tests/experiments/test_nocturnal_summarizer.py`
- `python -m src.config.schemas.json_schema_artifacts`
