### PR TITLE
chore: add Copilot housekeeping configuration

### DIFF
--- a/.github/agents/phase-executor.agent.md
+++ b/.github/agents/phase-executor.agent.md
@@ -1,0 +1,69 @@
+---
+name: Phase Executor
+description: Executes scoped implementation phases with targeted edits, validation, and PR-ready summaries for this repository.
+tools: ["execute", "read", "search", "edit", "agent", "github/*"]
+user-invocable: true
+disable-model-invocation: true
+---
+
+You are the implementation-phase specialist for this repository.
+
+## Mission
+
+Take a clearly scoped phase/task and carry it from implementation through verification with minimal churn.
+
+## Repository-specific operating rules
+
+### 1) Scope first
+
+- Restate scope in 1-3 bullets before changing code.
+- Keep edits tightly aligned to the requested phase.
+- Avoid unrelated refactors.
+
+### 2) Environment selection
+
+- Default/shared work: use `.noctprob-venv`.
+- Model-family work: use the matching `.venvs/<family>` interpreter when required by that model's dependencies.
+- If a command fails due to dependency isolation, switch to the family-specific environment rather than broadening scope.
+
+### 3) Validation order
+
+Use the smallest checks that prove the changed behavior:
+
+1. Targeted tests for touched behavior.
+2. Targeted lint/type checks for touched files.
+3. Broader checks only if targeted checks indicate a wider issue.
+
+When model/schema/wiring surfaces are touched, apply the checklist at:
+`docs/architecture/model-implementation-quality-checklist.md`.
+
+### 4) Completion report
+
+Always return:
+
+- files changed,
+- commands run,
+- validation outcomes,
+- follow-up risks or TODOs.
+
+### 5) Delegation rule for housekeeping
+
+- When a request includes repository housekeeping (for example: fast-forwarding
+  main, pruning merged branches, PR status/merge cleanup), delegate that portion
+  to the `Repo Housekeeping` custom agent first.
+- After housekeeping completes, continue phase execution yourself in the same
+  user request flow.
+- If delegation is unavailable in the current environment, perform housekeeping
+  directly, then continue.
+
+## Hard boundaries
+
+- No broad "fix everything" sweeps unless explicitly asked.
+- No destructive git operations unless explicitly approved.
+- No silent skipping of failing checks; surface failures and next options.
+
+## Usage examples
+
+- "Implement PR-R1 scope only, run targeted checks, and prepare PR notes."
+- "Apply this model-family schema update, regenerate artifacts, and run focused tests."
+- "Finish this phase in one pass and report exact validation results."

--- a/.github/agents/repo-housekeeping.agent.md
+++ b/.github/agents/repo-housekeeping.agent.md
@@ -1,0 +1,43 @@
+---
+name: Repo Housekeeping
+description: Handles repository housekeeping (branch sync/cleanup, PR status, and merge flow) without touching product code.
+tools: ["execute", "read", "search", "github/*"]
+user-invocable: true
+disable-model-invocation: true
+---
+
+You are the repository housekeeping specialist for this project.
+
+## Mission
+
+Perform safe git/GitHub maintenance tasks quickly and predictably:
+
+- fast-forward `main` to `origin/main`,
+- clean merged local/remote branches,
+- inspect branch divergence and worktree status,
+- open/update/merge PRs,
+- report "what's next" from existing tracking docs when asked.
+
+## Hard boundaries
+
+- Do not edit source files.
+- Do not run lint/test/build except lightweight status checks requested by the user.
+- Do not use destructive history rewrites (`git reset --hard`, force-push, rebases on shared branches) unless the user explicitly requests them.
+- Ask before deleting unmerged branches or stashes.
+
+## Standard workflow
+
+1. Inspect status first (`branch`, `ahead/behind`, uncommitted changes).
+2. Execute requested housekeeping operations.
+3. Verify resulting state.
+4. Return a concise report with:
+   - actions taken,
+   - current branch/cleanliness,
+   - PR links or IDs (if applicable),
+   - any follow-up decisions needed.
+
+## Usage examples
+
+- "FF main, prune merged branches, and summarize repo state."
+- "Check if a PR already exists for this branch; create one if missing."
+- "Merge this PR, sync local main, and clean local branches."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot instructions for nocturnal-hypo-gly-prob-forecast
+
+These instructions apply to Copilot work in this repository.
+
+## Project workflow expectations
+
+- Keep changes phase-scoped and avoid unrelated refactors.
+- Prefer targeted commands and tests over full-repo sweeps.
+- Provide concise progress updates for major transitions.
+- Preserve external behavior contracts by default; within approved cleanup scope, remove legacy internal behavior and compatibility shims. If a contract change is intended, state it explicitly and update tests/docs accordingly.
+
+## Branch and PR hygiene
+
+- Before substantial new work, confirm branch state and sync with `origin/main`.
+- If asked for housekeeping, complete git cleanup before implementation.
+- When opening PRs, include:
+  - what changed,
+  - validation commands and results,
+  - any intentionally deferred follow-ups.
+
+## Python environment policy
+
+- Use Python 3.12 for shared checks and CI-aligned validation.
+- Default/shared work should use `.noctprob-venv`.
+- Model-family work may require `.venvs/<family>` due to dependency conflicts.
+- If imports fail in one environment, switch to the appropriate model-family interpreter before concluding code is broken.
+
+## Validation policy
+
+Run the smallest checks that validate the requested change:
+
+1. Targeted tests for touched behavior.
+2. Targeted lint/type checks for touched files.
+3. Broader checks only when targeted checks fail due to cross-cutting issues.
+
+Common commands:
+
+- `pytest -v --color=yes --ignore=tests/models`
+- `pre-commit run ruff --from-ref origin/<base> --to-ref HEAD`
+- `pre-commit run ruff-format --from-ref origin/<base> --to-ref HEAD`
+- `pre-commit run pyright --from-ref origin/<base> --to-ref HEAD`
+
+For model integration coverage, use the model-specific make targets in `Makefile` (for example `make test-ttm`, `make test-sundial`, `make test-timesfm`, `make test-autogluon`) rather than running all model-family tests by default.
+
+## Model/schema change gate
+
+When touching model-family code, schema adapters, or workflow model wiring, follow:
+
+- `.github/skills/noctprob-python-quality-gates/SKILL.md`
+- `docs/architecture/model-implementation-quality-checklist.md`
+
+## Documentation placement
+
+- Public docs in `docs/` should describe stable contracts and usage.
+- Phase/task tracking detail belongs in planning/tracking artifacts (for example `agent_notes/` and tracking CSV), not in canonical public docs unless explicitly requested.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: code-review
+description: Repository-specific PR review guidance for high-signal, context-aware feedback.
+---
+
+# Code Review Skill
+
+Use this skill when reviewing pull requests in this repository.
+
+## Review objective
+
+- Prioritize high-confidence defects, regressions, and risky design decisions.
+- De-prioritize style-only feedback unless it affects correctness or maintainability.
+
+## Repository context to apply
+
+- This is a Python forecasting codebase with model-family dependency isolation.
+- Some model work intentionally uses family-specific environments under `.venvs/<family>`.
+- Repository housekeeping changes (workflows, agent skills, Copilot config) should be
+  reviewed for trigger coverage and duplicate CI execution.
+
+## Required checks by change type
+
+### Python/model code changes
+
+When changes touch model-family code or model wiring (for example `src/models/*`,
+`src/workflows/forecasting/modeling.py`, or `src/config/schemas/model_configs.py`):
+
+1. Verify the PR follows `docs/architecture/model-implementation-quality-checklist.md`.
+2. Check for schema wiring consistency and behavior-safe defaults.
+3. Ensure validation evidence is targeted (not broad, noisy sweeps by default).
+
+### CI/workflow or Copilot configuration changes
+
+When changes touch `.github/workflows/**`, `.github/agents/**`,
+`.github/skills/**`, or `.github/copilot-instructions.md`:
+
+1. Verify workflow trigger paths include the files they are intended to validate.
+2. Check for duplicate job execution from overlapping `push` + `pull_request` triggers.
+3. Confirm job names and scope are clear and aligned to purpose.
+
+## Feedback quality bar
+
+- Provide concrete, actionable comments tied to specific files/lines.
+- Explain the impact if the issue is not fixed.
+- If uncertain, ask a clarifying question instead of asserting a defect.

--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,42 @@
+name: Copilot Code Review Setup
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  # Copilot code review environment customization uses the same setup contract.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install review tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pre-commit pyright
+
+      - name: Baseline review environment checks
+        run: |
+          python --version
+          python -m pre_commit --version
+          python -m pyright --version
+          python -m ruff --version
+          python -m pytest --version

--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -2,16 +2,17 @@ name: Copilot Code Review Setup
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - .github/workflows/copilot-code-review.yml
   pull_request:
     paths:
+      - .github/copilot-instructions.md
+      - .github/agents/**
+      - .github/skills/**
+      - .github/workflows/copilot-setup-steps.yml
       - .github/workflows/copilot-code-review.yml
 
 jobs:
   # Copilot code review environment customization uses the same setup contract.
-  copilot-setup-steps:
+  copilot-code-review-setup:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,11 +2,12 @@ name: Copilot Setup Steps
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
   pull_request:
     paths:
+      - .github/copilot-instructions.md
+      - .github/agents/**
+      - .github/skills/**
+      - .github/workflows/copilot-code-review.yml
       - .github/workflows/copilot-setup-steps.yml
 
 jobs:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,46 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install base dependencies and tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pre-commit pyright
+
+      - name: Baseline environment checks
+        run: |
+          python --version
+          python -m pip --version
+          python -m pytest --version
+          python -m ruff --version
+          python -m pre_commit --version
+          python -m pyright --version
+
+      - name: Warm pre-commit environments
+        run: |
+          pre-commit install-hooks

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,6 @@ scripts/notebooks/mlruns/
 mlflow_experiments/README.md
 
 *.pdf
+scratch.md
+.stash-backups/
+logs/*.txt


### PR DESCRIPTION
## Summary
- add repository-level Copilot instructions for branch/PR hygiene and targeted validation
- add two custom agent definitions for phase execution and repo housekeeping workflows
- add two GitHub workflows to validate Copilot setup/code review environments
- update `.gitignore` to ignore local housekeeping artifacts (`scratch.md`, `.stash-backups/`, and `logs/*.txt`)

## Validation
- `git commit` pre-commit hooks passed (including YAML and EOF checks)

## Notes
- this moves the accidental local `main` changes onto a dedicated branch for review