### PR TITLE
P1-38 WS1 MC1: shared checkpoint path + payload helper extraction

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   # Copilot code review environment customization uses the same setup contract.
-  copilot-code-review-setup:
+  copilot-code-review:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -315,6 +315,8 @@ classes and standardize signatures/tests only.
 - Shared preprocessor artifact I/O helpers
   (`save_pickle_checkpoint_artifact`, `load_pickle_checkpoint_artifact`) wired
   for TTM preprocessor checkpoint flow: **(complete)**.
+- Shared checkpoint filename policy helper (`CHECKPOINT_FILENAME_POLICY`) wired
+  for TimesFM/TTM/Toto model-specific artifact naming: **(complete)**.
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -67,7 +67,7 @@ Not everything should be promoted to parent classes.
 - `Expected consolidated method name` is the planned post-consolidation target.
 - Analysis excludes `ttm/_deprecated` code and venv folders.
 
-Current snapshot: **142 methods/functions** across **15 model modules**.
+Current snapshot: **141 methods/functions** across **15 model modules**.
 
 <details>
 <summary>Expand full all-model LOC + caller-evidence matrix</summary>
@@ -83,8 +83,8 @@ Current snapshot: **142 methods/functions** across **15 model modules**.
 | _train_model | Execute model training/fine-tuning for the current backend. | 2 |  | Retain contract method, extract shared helper logic | _train_model -> wraps _shared_train_model | 56 | 48 | 168 | 191 | 93 | 35 | 44 | 39 | x | x | x | x | x | x | 5 |
 | _predict | Run single-input inference and return forecast outputs. | 5 |  | Retain contract method, extract shared helper logic | _predict -> wraps _shared_predict | 67 | 104 | 14 | 31 | 32 | 58 | 30 | 54 | x | x | x | x | x | x | 52 |
 | _predict_batch | Run multi-episode inference and return per-episode outputs. | 6 |  | Retain contract method, extract shared helper logic | _predict_batch -> wraps _shared_predict_batch | 46 | x | x | 64 | 43 | 29 | 31 | x | x | x | x | x | x | x | x |
-| _save_checkpoint | Persist model state and required runtime artifacts. | 4 |  | Retain contract method, extract shared helper logic | _save_checkpoint -> wraps _shared_save_checkpoint | 13 | 12 | 20 | 4 | 21 | 17 | 13 | 13 | x | x | x | x | x | x | 3 |
-| _load_checkpoint | Restore model state and required runtime artifacts. | 6 |  | Retain contract method, extract shared helper logic | _load_checkpoint -> wraps _shared_load_checkpoint | 66 | 10 | 48 | 39 | 38 | 34 | 15 | 29 | x | x | x | x | x | x | 3 |
+| _save_checkpoint | Persist model state and required runtime artifacts. | 4 |  | Retain contract method, extract shared helper logic | _save_checkpoint -> wraps _shared_save_checkpoint | 13 | 19 | 20 | 4 | 21 | 22 | 13 | 13 | x | x | x | x | x | x | 3 |
+| _load_checkpoint | Restore model state and required runtime artifacts. | 6 |  | Retain contract method, extract shared helper logic | _load_checkpoint -> wraps _shared_load_checkpoint | 66 | 13 | 48 | 39 | 38 | 39 | 15 | 29 | x | x | x | x | x | x | 3 |
 | _ag_item_id | Map an episode ID to the model item_id used for extraction. | 3 |  | Extract shared AutoGluon adapter helper | _ag_shared_ag_item_id | x | x | x | x | 10 | x | x | x | x | x | x | x | x | x | x |
 | _apply_univariate_patch | Monkey-patch pytorchts for univariate (target_dim=1) compatibility. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | x | x | 29 | x | x | x | x | x | x | x |
 | _autogluon_extract | Run fine-tuned model inference and extract specified columns. | 2 |  | Extract shared AutoGluon adapter helper | _ag_shared_autogluon_extract | x | x | x | x | 43 | x | x | x | x | x | x | x | x | x | x |
@@ -163,8 +163,8 @@ Current snapshot: **142 methods/functions** across **15 model modules**.
 | _list_intermediate_checkpoints | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_list_intermediate_checkpoints | x | x | x | x | 19 | x | x | x | x | x | x | x | x | x | x |
 | _load_darts_model | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | x | x | x | x | 9 | x | x | x | x | x |
 | _load_hf_model_weights | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | 16 | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _load_preprocessor_checkpoint | Load preprocessor artifact from known checkpoint locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_preprocessor_checkpoint | 20 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _load_saved_checkpoint_config | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_saved_checkpoint_config | x | 11 | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| _load_preprocessor_checkpoint | Load preprocessor artifact from known checkpoint locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_preprocessor_checkpoint | 23 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| _load_saved_checkpoint_config | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_saved_checkpoint_config | x | 14 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _log_column_specifiers | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | 4 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _log_dataset_sizes | Helper for data normalization/windowing/dataset assembly. | 1 |  | Extract shared data adapter helper | _shared_data_log_dataset_sizes | 9 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _log_training_start | Helper for training setup/execution. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | x | 8 | x | x | x | x | x | x | x | x |
@@ -196,7 +196,7 @@ Current snapshot: **142 methods/functions** across **15 model modules**.
 | _resolve_training_input_dtype | Helper for training setup/execution. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | 10 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _restore_trained_backbone | Restore best-validated backbone, falling back to final weights. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | 29 | x | x | x | x | x | x | x | x | x |
 | _run_forecast | Run forecaster and return BG predictions as numpy array. | 3 |  | Extract shared inference helper | _shared_inference_run_forecast | x | x | x | x | x | 10 | x | x | x | x | x | x | x | x | x |
-| _save_preprocessor_checkpoint | Persist preprocessor artifacts to checkpoint-compatible locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_save_preprocessor_checkpoint | 21 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| _save_preprocessor_checkpoint | Persist preprocessor artifacts to checkpoint-compatible locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_save_preprocessor_checkpoint | 24 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _save_training_config | Helper for training setup/execution. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | 4 | x | x | x | x | x | x | x | x | x | x | x |
 | _segment_patient_data | Apply gap handling and segment data by patient. | 1 |  | Extract shared data adapter helper | _shared_data_segment_patient_data | x | 23 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _select_patch_size | Choose a fixed patch size for training. | 2 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | 18 | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -211,7 +211,6 @@ Current snapshot: **142 methods/functions** across **15 model modules**.
 | _validate_preprocessor_schema | Validate preprocessor schema required by the current runtime. | 3 |  | Extract shared checkpoint helper | _shared_checkpoint_validate_preprocessor_schema | 14 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _validate_registered_quantile_levels | Helper for probabilistic/quantile forecast handling. | 4 |  | Extract shared inference helper | _shared_inference_validate_registered_quantile_levels | x | x | x | x | 15 | x | x | x | x | x | x | x | x | x | x |
 | _warn_quantiles_not_supported | Helper for probabilistic/quantile forecast handling. | 2 |  | Extract shared inference helper | _shared_inference_warn_quantiles_not_supported | 12 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _write_checkpoint_config | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_write_checkpoint_config | x | 3 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _write_snapshot_model_pt | Model-specific runtime helper. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_write_snapshot_model_pt | x | x | x | x | 11 | x | x | x | x | x | x | x | x | x | x |
 | _zero_shot_forecast | Run zero-shot inference via Chronos2Pipeline. | 2 |  | Extract shared inference helper | _shared_inference_zero_shot_forecast | x | x | x | x | 29 | x | x | x | x | x | x | x | x | x | x |
 | build_gluonts_dataset | Build a GluonTS ``ListDataset`` from a list of episode dicts. | 1 |  | Extract shared data adapter helper | _shared_data_build_gluonts_dataset | x | x | 63 | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -249,12 +248,12 @@ the planning estimate above stays fixed as the baseline target.
 
 | Model | Baseline current methods | Active current methods | Projected methods (target) | Active methods remaining | Baseline current LOC | Active current LOC | Projected LOC (target) | Active LOC remaining | Active method delta vs baseline | Active LOC delta vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| TTM | 37 | 37 | 20 | 17 | 1041 | 1024 | 191 | 833 | 0 | -17 |
-| TimesFM | 35 | 33 | 16 | 17 | 819 | 784 | 128 | 656 | -2 | -35 |
+| TTM | 37 | 37 | 20 | 17 | 1041 | 1030 | 191 | 839 | 0 | -11 |
+| TimesFM | 35 | 32 | 16 | 16 | 819 | 794 | 128 | 666 | -3 | -25 |
 | Moirai | 27 | 24 | 15 | 9 | 1024 | 792 | 104 | 688 | -3 | -232 |
 | Moment | 34 | 29 | 22 | 7 | 1074 | 954 | 312 | 642 | -5 | -120 |
 | Chronos2 | 32 | 32 | 17 | 15 | 883 | 883 | 119 | 764 | 0 | 0 |
-| Toto | 25 | 25 | 18 | 7 | 566 | 566 | 193 | 373 | 0 | 0 |
+| Toto | 25 | 25 | 18 | 7 | 566 | 576 | 193 | 383 | 0 | 10 |
 | Tide | 21 | 21 | 12 | 9 | 327 | 327 | 46 | 281 | 0 | 0 |
 | TimeGrad | 13 | 13 | 12 | 1 | 283 | 283 | 79 | 204 | 0 | 0 |
 | PatchTST | 2 | 2 | 1 | 1 | 16 | 16 | 2 | 14 | 0 | 0 |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -248,7 +248,7 @@ the planning estimate above stays fixed as the baseline target.
 
 | Model | Baseline current methods | Active current methods | Projected methods (target) | Active methods remaining | Baseline current LOC | Active current LOC | Projected LOC (target) | Active LOC remaining | Active method delta vs baseline | Active LOC delta vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| TTM | 37 | 35 | 20 | 15 | 1041 | 997 | 191 | 806 | -2 | -44 |
+| TTM | 37 | 35 | 20 | 15 | 1041 | 990 | 191 | 799 | -2 | -51 |
 | TimesFM | 35 | 32 | 16 | 16 | 819 | 794 | 128 | 666 | -3 | -25 |
 | Moirai | 27 | 24 | 15 | 9 | 1024 | 792 | 104 | 688 | -3 | -232 |
 | Moment | 34 | 29 | 22 | 7 | 1074 | 954 | 312 | 642 | -5 | -120 |
@@ -312,8 +312,9 @@ classes and standardize signatures/tests only.
   (`write_checkpoint_config_payload`, `read_checkpoint_config_payload`) wired
   for TimesFM + Toto checkpoint config flows: **(complete)**.
 - Shared preprocessor artifact I/O helpers
-  (`save_pickle_checkpoint_artifact`, `load_pickle_checkpoint_artifact`) wired
-  for TTM preprocessor checkpoint flow: **(complete)**.
+  (`_shared_save_preprocessor_artifact`,
+  `_shared_load_preprocessor_artifact`) wired for TTM preprocessor checkpoint
+  flow: **(complete)**.
 - Shared checkpoint filename policy helper (`CHECKPOINT_FILENAME_POLICY`) wired
   for TimesFM/TTM/Toto model-specific artifact naming: **(complete)**.
 - Shared checkpoint bundle helpers (`_shared_save_checkpoint_bundle`,
@@ -351,7 +352,7 @@ classes and standardize signatures/tests only.
 | `_shared_checkpoint_paths` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | checkpoint root + artifact names | canonical artifact path tuple |
 | `_shared_save_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | model state + metadata + destination path | persisted artifact bundle |
 | `_shared_load_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | checkpoint path + strictness policy | restored state + metadata or explicit error |
-| `_shared_preprocessor_artifact_io` | new helper under [src/models/base/](../src/models/base/) | preprocessor object + schema metadata + checkpoint paths | deterministic save/load of preprocessor artifacts |
+| `_shared_save_preprocessor_artifact` + `_shared_load_preprocessor_artifact` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | preprocessor object + schema metadata + checkpoint paths | deterministic save/load of preprocessor artifacts |
 
 ---
 

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -246,23 +246,28 @@ methods remain as thin wrappers/properties in child classes.
 This table is actively updated as methods/LOC move during implementation while
 the planning estimate above stays fixed as the baseline target.
 
+Calculation source (for consistency):
+`python scripts/analysis/calc_model_consolidation_metrics.py --format markdown`
+`Active current methods` = current `*Forecaster` method count in each `model.py`;
+`Active current LOC` = summed LOC of those methods (not full file LOC).
+
 | Model | Baseline current methods | Active current methods | Projected methods (target) | Active methods remaining | Baseline current LOC | Active current LOC | Projected LOC (target) | Active LOC remaining | Active method delta vs baseline | Active LOC delta vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| TTM | 37 | 35 | 20 | 15 | 1041 | 990 | 191 | 799 | -2 | -51 |
-| TimesFM | 35 | 32 | 16 | 16 | 819 | 794 | 128 | 666 | -3 | -25 |
+| TTM | 37 | 33 | 20 | 13 | 1041 | 978 | 191 | 787 | -4 | -63 |
+| TimesFM | 35 | 29 | 16 | 13 | 819 | 760 | 128 | 632 | -6 | -59 |
 | Moirai | 27 | 24 | 15 | 9 | 1024 | 792 | 104 | 688 | -3 | -232 |
-| Moment | 34 | 29 | 22 | 7 | 1074 | 954 | 312 | 642 | -5 | -120 |
-| Chronos2 | 32 | 28 | 17 | 11 | 883 | 777 | 119 | 658 | -4 | -106 |
-| Toto | 25 | 25 | 18 | 7 | 566 | 576 | 193 | 383 | 0 | 10 |
-| Tide | 21 | 21 | 12 | 9 | 327 | 327 | 46 | 281 | 0 | 0 |
-| TimeGrad | 13 | 13 | 12 | 1 | 283 | 283 | 79 | 204 | 0 | 0 |
-| PatchTST | 2 | 2 | 1 | 1 | 16 | 16 | 2 | 14 | 0 | 0 |
-| TSMixer | 5 | 5 | 4 | 1 | 64 | 64 | 48 | 16 | 0 | 0 |
-| DeepAR | 2 | 2 | 1 | 1 | 14 | 14 | 2 | 12 | 0 | 0 |
-| TFT | 2 | 2 | 1 | 1 | 14 | 14 | 2 | 12 | 0 | 0 |
-| Statistical | 2 | 2 | 1 | 1 | 20 | 20 | 2 | 18 | 0 | 0 |
+| Moment | 34 | 32 | 22 | 10 | 1074 | 982 | 312 | 670 | -2 | -92 |
+| Chronos2 | 32 | 28 | 17 | 11 | 883 | 767 | 119 | 648 | -4 | -116 |
+| Toto | 25 | 25 | 18 | 7 | 566 | 581 | 193 | 388 | 0 | 15 |
+| Tide | 21 | 20 | 12 | 8 | 327 | 319 | 46 | 273 | -1 | -8 |
+| TimeGrad | 13 | 11 | 12 | 0 | 283 | 241 | 79 | 162 | -2 | -42 |
+| PatchTST | 2 | 2 | 1 | 1 | 16 | 17 | 2 | 15 | 0 | 1 |
+| TSMixer | 5 | 5 | 4 | 1 | 64 | 66 | 48 | 18 | 0 | 2 |
+| DeepAR | 2 | 2 | 1 | 1 | 14 | 15 | 2 | 13 | 0 | 1 |
+| TFT | 2 | 2 | 1 | 1 | 14 | 15 | 2 | 13 | 0 | 1 |
+| Statistical | 2 | 2 | 1 | 1 | 20 | 21 | 2 | 19 | 0 | 1 |
 | NaiveBaseline | 2 | 2 | 1 | 1 | 9 | 9 | 2 | 7 | 0 | 0 |
-| Sundial | 10 | 10 | 10 | 0 | 105 | 105 | 34 | 71 | 0 | 0 |
+| Sundial | 10 | 10 | 10 | 0 | 105 | 108 | 34 | 74 | 0 | 3 |
 
 ## Benefits and negatives (with opinion)
 

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -307,6 +307,8 @@ classes and standardize signatures/tests only.
 - Shared checkpoint bundle helpers (`checkpoint_bundle_paths`,
   `write_checkpoint_json`, `read_checkpoint_json`) extracted and wired into
   base save/load/training-metadata flows: **(complete)**.
+- Shared model-artifact path helper (`_shared_checkpoint_paths`) extracted and
+  wired for TTM/TimesFM/Toto checkpoint artifact locations: **(complete)**.
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |
@@ -317,8 +319,8 @@ classes and standardize signatures/tests only.
 | `_train_model` | Family-local trainer/predictor orchestration. | Planned in MC3 (`_shared_training_*` helpers). | Child keeps orchestration wrapper, shared helpers handle reusable trainer mechanics. |
 | `_predict` | Family-local inference routing and output shaping. | Planned in MC4 (`_shared_inference_*` helpers). | Child keeps backend-specific inference routing and final family semantics. |
 | `_predict_batch` | Family-local episode batching/dispatch paths. | Planned in MC4 batch helpers. | Child keeps episode policy + backend-specific batching behavior. |
-| `_save_checkpoint` | Repeated JSON/path reference write logic across model classes. | **Now centralized in MC1** via `write_checkpoint_reference`; base save flow also centralizes config/metadata JSON writing via `write_checkpoint_json` and path mapping via `checkpoint_bundle_paths`. | Child only supplies family file naming and model-specific artifact decisions. |
-| `_load_checkpoint` | Repeated JSON/path resolve + fallback logic across model classes. | **Now centralized in MC1** via `resolve_checkpoint_reference`; base load flow also centralizes config/metadata JSON reading via `read_checkpoint_json` and bundle path mapping via `checkpoint_bundle_paths`. | Child keeps backend loader call + post-load state behavior (`is_fitted`, metadata use). |
+| `_save_checkpoint` | Repeated JSON/path reference write logic across model classes. | **Now centralized in MC1** via `write_checkpoint_reference`; base save flow also centralizes config/metadata JSON writing via `write_checkpoint_json`, bundle path mapping via `checkpoint_bundle_paths`, and artifact-name path resolution via `_shared_checkpoint_paths`. | Child only supplies family file naming and model-specific artifact decisions. |
+| `_load_checkpoint` | Repeated JSON/path resolve + fallback logic across model classes. | **Now centralized in MC1** via `resolve_checkpoint_reference`; base load flow also centralizes config/metadata JSON reading via `read_checkpoint_json`, bundle path mapping via `checkpoint_bundle_paths`, and artifact-name path resolution via `_shared_checkpoint_paths`. | Child keeps backend loader call + post-load state behavior (`is_fitted`, metadata use). |
 
 **Methods to standardize but keep in child classes**
 - `training_backend`, `supports_zero_shot`, `supports_probabilistic_forecast`
@@ -331,7 +333,7 @@ classes and standardize signatures/tests only.
 **Shared helper targets and contracts**
 | Expected consolidated method | Destination | Input contract | Output contract |
 | --- | --- | --- | --- |
-| `_shared_checkpoint_paths` | new helper under [src/models/base/](../src/models/base/) | checkpoint root + artifact policy | canonical path mapping |
+| `_shared_checkpoint_paths` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | checkpoint root + artifact names | canonical artifact path tuple |
 | `_shared_save_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | model state + metadata + destination path | persisted artifact bundle |
 | `_shared_load_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | checkpoint path + strictness policy | restored state + metadata or explicit error |
 | `_shared_preprocessor_artifact_io` | new helper under [src/models/base/](../src/models/base/) | preprocessor object + schema metadata + checkpoint paths | deterministic save/load of preprocessor artifacts |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -67,7 +67,7 @@ Not everything should be promoted to parent classes.
 - `Expected consolidated method name` is the planned post-consolidation target.
 - Analysis excludes `ttm/_deprecated` code and venv folders.
 
-Current snapshot: **141 methods/functions** across **15 model modules**.
+Current snapshot: **135 methods/functions** across **15 model modules**.
 
 <details>
 <summary>Expand full all-model LOC + caller-evidence matrix</summary>
@@ -103,7 +103,7 @@ Current snapshot: **141 methods/functions** across **15 model modules**.
 | _build_optional_data_loader | Helper for data normalization/windowing/dataset assembly. | 2 |  | Extract shared data adapter helper | _shared_data_build_optional_data_loader | 9 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _build_prediction_context | Build model context frame with item/timestamp index. | 3 |  | Extract shared AutoGluon adapter helper | _ag_shared_build_prediction_context | x | x | x | x | x | x | 16 | x | x | x | x | x | x | x | x |
 | _build_predictor_kwargs | Build TimeSeriesPredictor constructor kwargs for model. | 3 |  | Extract shared AutoGluon adapter helper | _ag_shared_build_predictor_kwargs | x | x | x | x | x | x | 12 | x | x | x | x | x | x | x | x |
-| _build_shadow_predictor_snapshot | Helper for AutoGluon adapter shaping/extraction. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_build_shadow_predictor_snapshot | x | x | x | x | 70 | x | x | x | x | x | x | x | x | x | x |
+| _build_shadow_predictor_snapshot | Helper for AutoGluon adapter shaping/extraction. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_build_shadow_predictor_snapshot | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _build_temporal_eval_dataset | Build temporal eval windows for mid-training callback. | 1 |  | Extract shared data adapter helper | _shared_data_build_temporal_eval_dataset | x | 58 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _build_train_val_arrays | Split patient segments into training and validation arrays. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | 36 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _build_trainer | Helper for training setup/execution. | 1 |  | Extract shared trainer helper | _shared_training_build_trainer | 15 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -160,10 +160,10 @@ Current snapshot: **141 methods/functions** across **15 model modules**.
 | _group_segments_by_patient | Group segmented arrays by original patient id. | 1 |  | Extract shared data adapter helper | _shared_data_group_segments_by_patient | x | 13 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _inverse_scale_predictions | Inverse scale predictions back to original units. | 1 |  | Extract shared inference helper | _shared_inference_inverse_scale_predictions | 102 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _iter_episode_dicts | Normalize dict/list training payloads to a flat episode list. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | 13 | x | x | x | x | x | x | x | x | x | x | x | x |
-| _list_intermediate_checkpoints | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_list_intermediate_checkpoints | x | x | x | x | 19 | x | x | x | x | x | x | x | x | x | x |
+| _list_intermediate_checkpoints | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_list_intermediate_checkpoints | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _load_darts_model | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | x | x | x | x | 9 | x | x | x | x | x |
 | _load_hf_model_weights | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | 16 | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _load_preprocessor_checkpoint | Load preprocessor artifact from known checkpoint locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_preprocessor_checkpoint | 23 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| _load_preprocessor_checkpoint | Load preprocessor artifact from known checkpoint locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_preprocessor_checkpoint | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _load_saved_checkpoint_config | Helper for checkpoint path/state handling. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_load_saved_checkpoint_config | x | 14 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _log_column_specifiers | Model-specific runtime helper. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | 4 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _log_dataset_sizes | Helper for data normalization/windowing/dataset assembly. | 1 |  | Extract shared data adapter helper | _shared_data_log_dataset_sizes | 9 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -186,7 +186,7 @@ Current snapshot: **141 methods/functions** across **15 model modules**.
 | _prepare_training_tensors | Convert training data to aligned tensor batches on CPU. | 3 |  | Extract shared data adapter helper | _shared_data_prepare_training_tensors | x | x | 111 | x | x | x | x | x | x | x | x | x | x | x | x |
 | _prepare_zero_shot_context | Validate target column and return a model context tensor. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | 17 | x | x | x | x | x | x | x | x | x | x |
 | _preprocessor_paths | Return supported preprocessor artifact locations for a checkpoint. | 2 |  | Extract shared checkpoint helper | _shared_checkpoint_preprocessor_paths | 6 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _rel_symlink | Model-specific runtime helper. | 5 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | 4 | x | x | x | x | x | x | x | x | x | x |
+| _rel_symlink | Model-specific runtime helper. | 5 |  | Extract shared checkpoint helper | _shared_checkpoint_rel_symlink | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _require_initialized_model | Return model object or raise if weights are not initialized. | 3 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | 5 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _resolve_eval_chunk_size | Resolve evaluation chunk size from config. | 4 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | 11 | x | x | x | x | x | x | x | x | x |
 | _resolve_freeze_backbone | Helper for runtime normalization/validation. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | 7 | x | x | x | x | x | x | x | x | x | x | x |
@@ -196,7 +196,7 @@ Current snapshot: **141 methods/functions** across **15 model modules**.
 | _resolve_training_input_dtype | Helper for training setup/execution. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | 10 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _restore_trained_backbone | Restore best-validated backbone, falling back to final weights. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | x | x | 29 | x | x | x | x | x | x | x | x | x |
 | _run_forecast | Run forecaster and return BG predictions as numpy array. | 3 |  | Extract shared inference helper | _shared_inference_run_forecast | x | x | x | x | x | 10 | x | x | x | x | x | x | x | x | x |
-| _save_preprocessor_checkpoint | Persist preprocessor artifacts to checkpoint-compatible locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_save_preprocessor_checkpoint | 24 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| _save_preprocessor_checkpoint | Persist preprocessor artifacts to checkpoint-compatible locations. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_save_preprocessor_checkpoint | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _save_training_config | Helper for training setup/execution. | 1 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | x | 4 | x | x | x | x | x | x | x | x | x | x | x |
 | _segment_patient_data | Apply gap handling and segment data by patient. | 1 |  | Extract shared data adapter helper | _shared_data_segment_patient_data | x | 23 | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _select_patch_size | Choose a fixed patch size for training. | 2 |  | Retain family-specific (no safe consolidation yet) | retain family-specific | x | x | 18 | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -211,7 +211,7 @@ Current snapshot: **141 methods/functions** across **15 model modules**.
 | _validate_preprocessor_schema | Validate preprocessor schema required by the current runtime. | 3 |  | Extract shared checkpoint helper | _shared_checkpoint_validate_preprocessor_schema | 14 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _validate_registered_quantile_levels | Helper for probabilistic/quantile forecast handling. | 4 |  | Extract shared inference helper | _shared_inference_validate_registered_quantile_levels | x | x | x | x | 15 | x | x | x | x | x | x | x | x | x | x |
 | _warn_quantiles_not_supported | Helper for probabilistic/quantile forecast handling. | 2 |  | Extract shared inference helper | _shared_inference_warn_quantiles_not_supported | 12 | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
-| _write_snapshot_model_pt | Model-specific runtime helper. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_write_snapshot_model_pt | x | x | x | x | 11 | x | x | x | x | x | x | x | x | x | x |
+| _write_snapshot_model_pt | Model-specific runtime helper. | 1 |  | Extract shared checkpoint helper | _shared_checkpoint_write_snapshot_model_pt | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | _zero_shot_forecast | Run zero-shot inference via Chronos2Pipeline. | 2 |  | Extract shared inference helper | _shared_inference_zero_shot_forecast | x | x | x | x | 29 | x | x | x | x | x | x | x | x | x | x |
 | build_gluonts_dataset | Build a GluonTS ``ListDataset`` from a list of episode dicts. | 1 |  | Extract shared data adapter helper | _shared_data_build_gluonts_dataset | x | x | 63 | x | x | x | x | x | x | x | x | x | x | x | x |
 | evaluate | Evaluate model on test data using rolling-window evaluation. | 1 |  | Move to family utility module | MOVE to <family>/utils.py | x | 107 | x | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -248,11 +248,11 @@ the planning estimate above stays fixed as the baseline target.
 
 | Model | Baseline current methods | Active current methods | Projected methods (target) | Active methods remaining | Baseline current LOC | Active current LOC | Projected LOC (target) | Active LOC remaining | Active method delta vs baseline | Active LOC delta vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| TTM | 37 | 37 | 20 | 17 | 1041 | 1030 | 191 | 839 | 0 | -11 |
+| TTM | 37 | 35 | 20 | 15 | 1041 | 997 | 191 | 806 | -2 | -44 |
 | TimesFM | 35 | 32 | 16 | 16 | 819 | 794 | 128 | 666 | -3 | -25 |
 | Moirai | 27 | 24 | 15 | 9 | 1024 | 792 | 104 | 688 | -3 | -232 |
 | Moment | 34 | 29 | 22 | 7 | 1074 | 954 | 312 | 642 | -5 | -120 |
-| Chronos2 | 32 | 32 | 17 | 15 | 883 | 883 | 119 | 764 | 0 | 0 |
+| Chronos2 | 32 | 28 | 17 | 11 | 883 | 777 | 119 | 658 | -4 | -106 |
 | Toto | 25 | 25 | 18 | 7 | 566 | 576 | 193 | 383 | 0 | 10 |
 | Tide | 21 | 21 | 12 | 9 | 327 | 327 | 46 | 281 | 0 | 0 |
 | TimeGrad | 13 | 13 | 12 | 1 | 283 | 283 | 79 | 204 | 0 | 0 |
@@ -316,6 +316,14 @@ classes and standardize signatures/tests only.
   for TTM preprocessor checkpoint flow: **(complete)**.
 - Shared checkpoint filename policy helper (`CHECKPOINT_FILENAME_POLICY`) wired
   for TimesFM/TTM/Toto model-specific artifact naming: **(complete)**.
+- Shared checkpoint bundle helpers (`_shared_save_checkpoint_bundle`,
+  `_shared_load_checkpoint_bundle`) wired into base save/load and
+  training-metadata persistence paths: **(complete)**.
+- Chronos2 intermediate-checkpoint materialization helpers moved from
+  model-local methods into shared checkpoint helper module: **(complete)**.
+- TTM preprocessor checkpoint save/load wrappers removed from model-local
+  methods; checkpoint artifact I/O now uses shared helper functions directly:
+  **(complete)**.
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -309,6 +309,9 @@ classes and standardize signatures/tests only.
   base save/load/training-metadata flows: **(complete)**.
 - Shared model-artifact path helper (`_shared_checkpoint_paths`) extracted and
   wired for TTM/TimesFM/Toto checkpoint artifact locations: **(complete)**.
+- Shared checkpoint config payload helpers
+  (`write_checkpoint_config_payload`, `read_checkpoint_config_payload`) wired
+  for TimesFM + Toto checkpoint config flows: **(complete)**.
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -367,6 +367,12 @@ classes and standardize signatures/tests only.
 
 **Target model.py LOC reduction:** **180-260 LOC**
 
+**MC3 progress**
+- Moment C3 slice 1: `_predict_batch` decomposed into focused helpers
+  (`_validate_predict_batch_request`, `_collect_episode_contexts`,
+  `_pad_batch_contexts`, `_forecast_episode_batches`) while preserving the
+  public batch inference contract and chunking behavior: **(complete)**.
+
 **Shared helper targets and contracts**
 | Expected consolidated method | Destination | Input contract | Output contract |
 | --- | --- | --- | --- |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -312,6 +312,9 @@ classes and standardize signatures/tests only.
 - Shared checkpoint config payload helpers
   (`write_checkpoint_config_payload`, `read_checkpoint_config_payload`) wired
   for TimesFM + Toto checkpoint config flows: **(complete)**.
+- Shared preprocessor artifact I/O helpers
+  (`save_pickle_checkpoint_artifact`, `load_pickle_checkpoint_artifact`) wired
+  for TTM preprocessor checkpoint flow: **(complete)**.
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -357,8 +357,8 @@ classes and standardize signatures/tests only.
 | Expected consolidated method | Destination | Input contract | Output contract |
 | --- | --- | --- | --- |
 | `_shared_checkpoint_paths` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | checkpoint root + artifact names | canonical artifact path tuple |
-| `_shared_save_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | model state + metadata + destination path | persisted artifact bundle |
-| `_shared_load_checkpoint_bundle` | new helper under [src/models/base/](../src/models/base/) | checkpoint path + strictness policy | restored state + metadata or explicit error |
+| `_shared_save_checkpoint_bundle` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | model state + metadata + destination path | persisted artifact bundle |
+| `_shared_load_checkpoint_bundle` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | checkpoint path + strictness policy | restored state + metadata or explicit error |
 | `_shared_save_preprocessor_artifact` + `_shared_load_preprocessor_artifact` | [checkpoint_helpers.py](../src/models/base/checkpoint_helpers.py) **(complete)** | preprocessor object + schema metadata + checkpoint paths | deterministic save/load of preprocessor artifacts |
 
 ---
@@ -366,6 +366,17 @@ classes and standardize signatures/tests only.
 ### MC2 — Training-data normalization + dataset assembly
 
 **Target model.py LOC reduction:** **220-320 LOC**
+
+**Lifecycle carryover work items (`_prepare_training_data`)**
+- TTM: reduce remaining input normalization + loader wiring in
+  [ttm/model.py](../src/models/ttm/model.py).
+- TimesFM: continue patient/window prep extraction in
+  [timesfm/model.py](../src/models/timesfm/model.py).
+- Moirai: continue multi-input adaptation cleanup in
+  [moirai/model.py](../src/models/moirai/model.py).
+- Moment: move reusable context/target pair assembly boundaries from
+  [moment/model.py](../src/models/moment/model.py) into shared data helpers where
+  semantics match.
 
 **Shared helper targets and contracts**
 | Expected consolidated method | Destination | Input contract | Output contract |
@@ -383,11 +394,17 @@ classes and standardize signatures/tests only.
 
 **Target model.py LOC reduction:** **180-260 LOC**
 
-**MC3 progress**
-- Moment C3 slice 1: `_predict_batch` decomposed into focused helpers
-  (`_validate_predict_batch_request`, `_collect_episode_contexts`,
-  `_pad_batch_contexts`, `_forecast_episode_batches`) while preserving the
-  public batch inference contract and chunking behavior: **(complete)**.
+**Lifecycle carryover work items (`_train_model`)**
+- TTM: isolate trainer-setup/eval orchestration in
+  [ttm/model.py](../src/models/ttm/model.py) behind shared training helper
+  contracts.
+- TimesFM: continue callback/trainer setup extraction in
+  [timesfm/model.py](../src/models/timesfm/model.py).
+- Moirai: simplify fit-time orchestration flow in
+  [moirai/model.py](../src/models/moirai/model.py).
+- Moment: decompose monolithic training loop in
+  [moment/model.py](../src/models/moment/model.py) into shared trainer helper
+  boundaries.
 
 **Shared helper targets and contracts**
 | Expected consolidated method | Destination | Input contract | Output contract |
@@ -403,6 +420,14 @@ classes and standardize signatures/tests only.
 ### MC4 — Inference/batch/quantile helper reuse
 
 **Target model.py LOC reduction:** **240-360 LOC**
+
+**Lifecycle carryover work items (`_predict`, `_predict_batch`)**
+- Chronos2/TiDE: continue harmonizing AutoGluon inference/batch helper surfaces.
+- TTM/TimesFM/Toto/Moirai/Moment: extract shared single/batch output-shaping and
+  quantile validation utilities where semantics match.
+- Moment note: current `_predict_batch` helper decomposition in
+  [moment/model.py](../src/models/moment/model.py) is preparatory refactor only;
+  MC4 shared inference extraction is still pending.
 
 **Shared helper targets and contracts**
 | Expected consolidated method | Destination | Input contract | Output contract |

--- a/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
+++ b/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md
@@ -325,6 +325,13 @@ classes and standardize signatures/tests only.
 - TTM preprocessor checkpoint save/load wrappers removed from model-local
   methods; checkpoint artifact I/O now uses shared helper functions directly:
   **(complete)**.
+- Post-refactor smoke verification:
+  `SUITE_LABEL=post_refactor_20260828_mc1_closeout make smoke-suite-aleppo`
+  and suite comparison vs
+  `post_refactor_20260827_c7/suite_manifest.json` passed with **0**
+  discrepancies (`model_count_compared=14`, `failures=[]`): **(complete)**.
+
+**MC1 status:** **complete** (checkpoint/lifecycle helper extraction scope closed).
 
 **Lifecycle mapping (before -> after)**
 | Lifecycle method | Before (child-owned implementation) | Centralized helper logic | After (child wrapper ownership) |

--- a/scripts/analysis/calc_model_consolidation_metrics.py
+++ b/scripts/analysis/calc_model_consolidation_metrics.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Compute consistent per-model method and LOC metrics for consolidation tracking."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+MODEL_PATHS = {
+    "TTM": "src/models/ttm/model.py",
+    "TimesFM": "src/models/timesfm/model.py",
+    "Moirai": "src/models/moirai/model.py",
+    "Moment": "src/models/moment/model.py",
+    "Chronos2": "src/models/chronos2/model.py",
+    "Toto": "src/models/toto/model.py",
+    "Tide": "src/models/tide/model.py",
+    "TimeGrad": "src/models/timegrad/model.py",
+    "PatchTST": "src/models/patchtst/model.py",
+    "TSMixer": "src/models/tsmixer/model.py",
+    "DeepAR": "src/models/deepar/model.py",
+    "TFT": "src/models/tft/model.py",
+    "Statistical": "src/models/statistical/model.py",
+    "NaiveBaseline": "src/models/naive_baseline/model.py",
+    "Sundial": "src/models/sundial/model.py",
+}
+
+
+@dataclass(frozen=True)
+class ModelMetrics:
+    model: str
+    path: str
+    method_count: int
+    method_loc: int
+    file_loc: int
+    file_nonempty_loc: int
+
+
+def _class_name_is_forecaster(node: ast.ClassDef) -> bool:
+    return node.name.endswith("Forecaster")
+
+
+def _extract_forecaster_methods(
+    tree: ast.Module,
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and _class_name_is_forecaster(node):
+            return [
+                member
+                for member in node.body
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+    raise ValueError("No *Forecaster class found in module.")
+
+
+def _compute_metrics(repo_root: Path, model: str, rel_path: str) -> ModelMetrics:
+    path = repo_root / rel_path
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    tree = ast.parse(source)
+    methods = _extract_forecaster_methods(tree)
+    method_loc = sum(
+        int(member.end_lineno or member.lineno) - int(member.lineno) + 1
+        for member in methods
+    )
+    file_nonempty_loc = sum(1 for line in lines if line.strip())
+    return ModelMetrics(
+        model=model,
+        path=rel_path,
+        method_count=len(methods),
+        method_loc=method_loc,
+        file_loc=len(lines),
+        file_nonempty_loc=file_nonempty_loc,
+    )
+
+
+def _render_markdown(metrics: list[ModelMetrics]) -> str:
+    rows = [
+        "| Model | Method count | Method LOC | File LOC | File non-empty LOC | Path |",
+        "| --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for item in metrics:
+        rows.append(
+            f"| {item.model} | {item.method_count} | {item.method_loc} | "
+            f"{item.file_loc} | {item.file_nonempty_loc} | `{item.path}` |"
+        )
+    return "\n".join(rows)
+
+
+def _render_csv(metrics: list[ModelMetrics]) -> str:
+    rows = ["model,path,method_count,method_loc,file_loc,file_nonempty_loc"]
+    for item in metrics:
+        rows.append(
+            f"{item.model},{item.path},{item.method_count},{item.method_loc},"
+            f"{item.file_loc},{item.file_nonempty_loc}"
+        )
+    return "\n".join(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute per-model method and LOC metrics for consolidation tracking."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root path (default: inferred from script location).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "csv"),
+        default="markdown",
+        help="Output format.",
+    )
+    args = parser.parse_args()
+
+    metrics = [
+        _compute_metrics(args.repo_root, model, rel_path)
+        for model, rel_path in MODEL_PATHS.items()
+    ]
+
+    if args.format == "csv":
+        print(_render_csv(metrics))
+    else:
+        print(_render_markdown(metrics))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/autogluon_base.py
+++ b/src/models/autogluon_base.py
@@ -38,6 +38,7 @@ from .autogluon_data_utils import (
 )
 from .base import BaseTimeSeriesFoundationModel, TrainingBackend
 from .base.checkpoint_helpers import (
+    CHECKPOINT_PATH_KEY,
     resolve_checkpoint_reference,
     write_checkpoint_reference,
 )
@@ -243,7 +244,10 @@ class AutoGluonBaseModel(BaseTimeSeriesFoundationModel):
 
         info_print(f"Training complete. Predictor saved to {predictor.path}")
         return {
-            "train_metrics": {"status": "completed", "predictor_path": predictor.path}
+            "train_metrics": {
+                CHECKPOINT_PATH_KEY: predictor.path,
+                "status": "completed",
+            }
         }
 
     # ------------------------------------------------------------------

--- a/src/models/base/base_model.py
+++ b/src/models/base/base_model.py
@@ -10,7 +10,6 @@ different time series foundation models in a unified framework.
 """
 
 import logging
-import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -23,9 +22,9 @@ import torch
 # Local imports
 from ...utils.logging_helper import info_print
 from .checkpoint_helpers import (
-    checkpoint_bundle_paths,
+    _shared_load_checkpoint_bundle,
+    _shared_save_checkpoint_bundle,
     read_checkpoint_json,
-    write_checkpoint_json,
 )
 
 
@@ -575,16 +574,9 @@ class BaseTimeSeriesFoundationModel(ABC):
             configuration and metadata, then save model-specific weights
             via _save_checkpoint().
         """
-        os.makedirs(model_path, exist_ok=True)
-        paths = checkpoint_bundle_paths(model_path)
-
-        # Save configuration
-        if save_config:
-            write_checkpoint_json(paths.config_json, self.config.to_dict())
-
-        # Save metadata
+        metadata_payload: Optional[Dict[str, Any]] = None
         if save_metadata:
-            metadata = {
+            metadata_payload = {
                 "model_type": self.__class__.__name__,
                 "is_fitted": self.is_fitted,
                 "training_history": self.training_history,
@@ -592,7 +584,11 @@ class BaseTimeSeriesFoundationModel(ABC):
                 "config": self.config.to_dict(),
                 "training_backend": self.training_backend.value,
             }
-            write_checkpoint_json(paths.metadata_json, metadata)
+        _shared_save_checkpoint_bundle(
+            model_path,
+            config_payload=self.config.to_dict() if save_config else None,
+            metadata_payload=metadata_payload,
+        )
 
         # Save model-specific checkpoint files (weights, optimizer state, etc.)
         self._save_checkpoint(model_path)
@@ -613,15 +609,13 @@ class BaseTimeSeriesFoundationModel(ABC):
         Returns:
             Loaded model instance
         """
-        paths = checkpoint_bundle_paths(model_path)
+        bundle = _shared_load_checkpoint_bundle(model_path)
 
         # Load config if not provided
         if config is None:
-            if os.path.exists(paths.config_json):
-                config_dict = read_checkpoint_json(paths.config_json)
-                config = cls.config_class.from_dict(config_dict)
-            else:
-                raise ValueError(f"No config found at {paths.config_json}")
+            if bundle.config is None:
+                raise ValueError(f"No config found at {bundle.paths.config_json}")
+            config = cls.config_class.from_dict(bundle.config)
         if config is None:
             raise ValueError(f"Unable to load model config from {model_path}")
 
@@ -634,13 +628,9 @@ class BaseTimeSeriesFoundationModel(ABC):
 
         # Load metadata - check both metadata.json (from save_model) and
         # training_metadata.json (from fit) for backward compatibility
-        metadata = {}
-        if os.path.exists(paths.metadata_json):
-            metadata = read_checkpoint_json(paths.metadata_json)
-            info_print(f"Loaded metadata from {paths.metadata_json}")
-        elif os.path.exists(paths.training_metadata_json):
-            metadata = read_checkpoint_json(paths.training_metadata_json)
-            info_print(f"Loaded metadata from {paths.training_metadata_json}")
+        metadata = dict(bundle.metadata)
+        if bundle.metadata_path is not None:
+            info_print(f"Loaded metadata from {bundle.metadata_path}")
             # Extract training_history from metrics if present
             if "metrics" in metadata and "training_history" in metadata["metrics"]:
                 metadata["training_history"] = metadata["metrics"]["training_history"]
@@ -731,8 +721,6 @@ class BaseTimeSeriesFoundationModel(ABC):
             Git information (commit, branch, dirty state) is captured if
             GitPython is installed and the code is in a git repository.
         """
-        paths = checkpoint_bundle_paths(output_dir)
-
         # Add additional metadata
         metadata = {
             "model_type": self.__class__.__name__,
@@ -754,8 +742,10 @@ class BaseTimeSeriesFoundationModel(ABC):
             # This catches ImportError (GitPython not installed) and any git-related errors
             pass
 
-        write_checkpoint_json(paths.training_metadata_json, metadata)
-
+        paths = _shared_save_checkpoint_bundle(
+            output_dir,
+            training_metadata_payload=metadata,
+        )
         info_print(f"Training metadata saved to {paths.training_metadata_json}")
 
     # Dunder methods

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import pickle
+import shutil
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 CHECKPOINT_PATH_KEY = "predictor_path"
 CHECKPOINT_WEIGHTS_FILE_KEY = "weights_file"
@@ -20,6 +22,16 @@ class CheckpointBundlePaths:
     config_json: str
     metadata_json: str
     training_metadata_json: str
+
+
+@dataclass(frozen=True)
+class LoadedCheckpointBundle:
+    """Loaded checkpoint bundle payloads and source paths."""
+
+    paths: CheckpointBundlePaths
+    config: dict[str, Any] | None
+    metadata: dict[str, Any]
+    metadata_path: str | None
 
 
 @dataclass(frozen=True)
@@ -53,6 +65,49 @@ def checkpoint_bundle_paths(model_dir: str) -> CheckpointBundlePaths:
         config_json=os.path.join(model_dir, "config.json"),
         metadata_json=os.path.join(model_dir, "metadata.json"),
         training_metadata_json=os.path.join(model_dir, "training_metadata.json"),
+    )
+
+
+def _shared_save_checkpoint_bundle(
+    model_dir: str,
+    *,
+    config_payload: dict[str, Any] | None = None,
+    metadata_payload: dict[str, Any] | None = None,
+    training_metadata_payload: dict[str, Any] | None = None,
+) -> CheckpointBundlePaths:
+    """Write standard checkpoint-bundle JSON payloads under ``model_dir``."""
+    os.makedirs(model_dir, exist_ok=True)
+    paths = checkpoint_bundle_paths(model_dir)
+    if config_payload is not None:
+        write_checkpoint_json(paths.config_json, config_payload)
+    if metadata_payload is not None:
+        write_checkpoint_json(paths.metadata_json, metadata_payload)
+    if training_metadata_payload is not None:
+        write_checkpoint_json(paths.training_metadata_json, training_metadata_payload)
+    return paths
+
+
+def _shared_load_checkpoint_bundle(model_dir: str) -> LoadedCheckpointBundle:
+    """Load standard checkpoint bundle JSON payloads from ``model_dir``."""
+    paths = checkpoint_bundle_paths(model_dir)
+    config: dict[str, Any] | None = None
+    if os.path.exists(paths.config_json):
+        config = read_checkpoint_json(paths.config_json)
+
+    metadata: dict[str, Any] = {}
+    metadata_path: str | None = None
+    if os.path.exists(paths.metadata_json):
+        metadata_path = paths.metadata_json
+        metadata = read_checkpoint_json(paths.metadata_json)
+    elif os.path.exists(paths.training_metadata_json):
+        metadata_path = paths.training_metadata_json
+        metadata = read_checkpoint_json(paths.training_metadata_json)
+
+    return LoadedCheckpointBundle(
+        paths=paths,
+        config=config,
+        metadata=metadata,
+        metadata_path=metadata_path,
     )
 
 
@@ -123,6 +178,134 @@ def load_pickle_checkpoint_artifact(
         with open(path, "rb") as handle:
             return pickle_module.load(handle), path
     return None, None
+
+
+def _relative_symlink(target: str, link: str) -> None:
+    os.symlink(os.path.relpath(os.path.abspath(target), os.path.dirname(link)), link)
+
+
+def list_intermediate_checkpoint_adapters(
+    w0_dir: str,
+    *,
+    adapter_filename: str = "adapter_model.safetensors",
+    log_fn: Callable[[str], None] | None = None,
+) -> list[tuple[str, int, str]]:
+    """Return intermediate checkpoint dirs that contain LoRA adapter weights."""
+    checkpoints = sorted(
+        [
+            d
+            for d in os.listdir(w0_dir)
+            if d.startswith("checkpoint-") and os.path.isdir(os.path.join(w0_dir, d))
+        ],
+        key=lambda checkpoint_name: int(checkpoint_name.split("-")[1]),
+    )
+    materializable: list[tuple[str, int, str]] = []
+    for checkpoint_name in checkpoints:
+        step_num = int(checkpoint_name.split("-")[1])
+        adapter_src = os.path.join(w0_dir, checkpoint_name, adapter_filename)
+        if not os.path.exists(adapter_src):
+            if log_fn is not None:
+                log_fn(f"  {checkpoint_name}: no {adapter_filename}, skipping")
+            continue
+        materializable.append((checkpoint_name, step_num, adapter_src))
+    return materializable
+
+
+def build_chronos2_shadow_predictor_snapshot(
+    *,
+    output_dir: str,
+    w0_dir: str,
+    adapter_src: str,
+    shadow_predictor: str,
+) -> None:
+    """Create a Chronos2 shadow predictor tree with a swapped adapter checkpoint."""
+    os.makedirs(shadow_predictor, exist_ok=True)
+    for entry in os.listdir(output_dir):
+        if entry in ("models", "snapshots"):
+            continue
+        _relative_symlink(
+            os.path.join(output_dir, entry),
+            os.path.join(shadow_predictor, entry),
+        )
+
+    models_orig = os.path.join(output_dir, "models")
+    shadow_models = os.path.join(shadow_predictor, "models")
+    os.makedirs(shadow_models, exist_ok=True)
+    for entry in os.listdir(models_orig):
+        if entry == "Chronos2":
+            continue
+        _relative_symlink(
+            os.path.join(models_orig, entry),
+            os.path.join(shadow_models, entry),
+        )
+
+    shadow_c2 = os.path.join(shadow_models, "Chronos2")
+    os.makedirs(shadow_c2, exist_ok=True)
+    c2_orig = os.path.join(models_orig, "Chronos2")
+    for entry in os.listdir(c2_orig):
+        if entry == "W0":
+            continue
+        _relative_symlink(
+            os.path.join(c2_orig, entry),
+            os.path.join(shadow_c2, entry),
+        )
+
+    shadow_w0 = os.path.join(shadow_c2, "W0")
+    os.makedirs(shadow_w0, exist_ok=True)
+    for entry in os.listdir(w0_dir):
+        if entry == "fine-tuned-ckpt" or entry.startswith("checkpoint-"):
+            continue
+        if entry == "model.pkl":
+            with open(os.path.join(w0_dir, "model.pkl"), "rb") as model_file:
+                w0_model = pickle.load(model_file)
+            w0_model.path = os.path.abspath(shadow_w0)
+            with open(os.path.join(shadow_w0, "model.pkl"), "wb") as model_file:
+                pickle.dump(w0_model, model_file)
+            continue
+        _relative_symlink(
+            os.path.join(w0_dir, entry),
+            os.path.join(shadow_w0, entry),
+        )
+
+    orig_ft_ckpt = os.path.join(w0_dir, "fine-tuned-ckpt")
+    shadow_ft_ckpt = os.path.join(shadow_w0, "fine-tuned-ckpt")
+    os.makedirs(shadow_ft_ckpt, exist_ok=True)
+    for entry in os.listdir(orig_ft_ckpt):
+        if entry == "adapter_model.safetensors":
+            continue
+        _relative_symlink(
+            os.path.join(orig_ft_ckpt, entry),
+            os.path.join(shadow_ft_ckpt, entry),
+        )
+    shutil.copy2(
+        adapter_src,
+        os.path.join(shadow_ft_ckpt, "adapter_model.safetensors"),
+    )
+
+
+def write_snapshot_model_pt_bundle(
+    *,
+    snapshot_dir: str,
+    main_model_pt: str,
+    predictor_reference_filename: str,
+    predictor_target_path: str,
+    config_payload: dict[str, Any],
+) -> str:
+    """Write model.pt snapshot payload for an intermediate checkpoint."""
+    snapshot_model_pt = os.path.join(snapshot_dir, "model.pt")
+    os.makedirs(snapshot_model_pt, exist_ok=True)
+    write_checkpoint_reference(
+        output_dir=snapshot_model_pt,
+        reference_filename=predictor_reference_filename,
+        target_path=predictor_target_path,
+    )
+    write_checkpoint_json(
+        os.path.join(snapshot_model_pt, "config.json"), config_payload
+    )
+    meta_src = os.path.join(main_model_pt, "metadata.json")
+    if os.path.exists(meta_src):
+        shutil.copy2(meta_src, os.path.join(snapshot_model_pt, "metadata.json"))
+    return snapshot_model_pt
 
 
 def write_checkpoint_reference(

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -8,6 +8,9 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+CHECKPOINT_PATH_KEY = "predictor_path"
+CHECKPOINT_WEIGHTS_FILE_KEY = "weights_file"
+
 
 @dataclass(frozen=True)
 class CheckpointBundlePaths:
@@ -127,7 +130,7 @@ def write_checkpoint_reference(
     reference_filename: str,
     target_path: str,
     *,
-    path_key: str = "predictor_path",
+    path_key: str = CHECKPOINT_PATH_KEY,
     relative_to_output: bool = False,
 ) -> str:
     """Write a JSON file that stores a checkpoint-related filesystem path."""
@@ -145,7 +148,7 @@ def resolve_checkpoint_reference(
     model_dir: str,
     reference_filename: str,
     *,
-    path_key: str = "predictor_path",
+    path_key: str = CHECKPOINT_PATH_KEY,
     required_file: str | None = None,
     logger: logging.Logger | None = None,
 ) -> str:

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -69,6 +69,44 @@ def read_checkpoint_config_payload(
     return read_checkpoint_json(config_path)
 
 
+def save_pickle_checkpoint_artifact(
+    artifact: Any,
+    *,
+    paths: tuple[str, ...],
+    pickle_module: Any,
+    write_missing_parent_paths: bool = False,
+) -> tuple[str, ...]:
+    """Persist a pickle artifact to one or more candidate checkpoint paths."""
+    written_paths: list[str] = []
+    for idx, path in enumerate(paths):
+        parent_dir = os.path.dirname(path) or "."
+        if idx == 0:
+            os.makedirs(parent_dir, exist_ok=True)
+        elif not os.path.exists(parent_dir):
+            if write_missing_parent_paths:
+                os.makedirs(parent_dir, exist_ok=True)
+            else:
+                continue
+        with open(path, "wb") as handle:
+            pickle_module.dump(artifact, handle)
+        written_paths.append(path)
+    return tuple(written_paths)
+
+
+def load_pickle_checkpoint_artifact(
+    *,
+    paths: tuple[str, ...],
+    pickle_module: Any,
+) -> tuple[Any | None, str | None]:
+    """Load the first available pickle artifact from candidate paths."""
+    for path in paths:
+        if not os.path.exists(path):
+            continue
+        with open(path, "rb") as handle:
+            return pickle_module.load(handle), path
+    return None, None
+
+
 def write_checkpoint_reference(
     output_dir: str,
     reference_filename: str,

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -19,6 +19,15 @@ class CheckpointBundlePaths:
     training_metadata_json: str
 
 
+def _shared_checkpoint_paths(base_dir: str, *relative_paths: str) -> tuple[str, ...]:
+    """Resolve model-specific artifact names to full checkpoint paths."""
+    if not relative_paths:
+        raise ValueError("At least one relative artifact path is required.")
+    return tuple(
+        os.path.join(base_dir, relative_path) for relative_path in relative_paths
+    )
+
+
 def checkpoint_bundle_paths(model_dir: str) -> CheckpointBundlePaths:
     """Return canonical bundle paths rooted at ``model_dir``."""
     return CheckpointBundlePaths(

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -19,6 +19,21 @@ class CheckpointBundlePaths:
     training_metadata_json: str
 
 
+@dataclass(frozen=True)
+class CheckpointFilenamePolicy:
+    """Shared artifact naming policy for model-specific checkpoint bundles."""
+
+    ttm_preprocessor_artifacts: tuple[str, str] = (
+        "preprocessor.pkl",
+        "model.pt/preprocessor.pkl",
+    )
+    timesfm_artifacts: tuple[str, str] = ("hf_model", "timesfm_config.json")
+    toto_artifacts: tuple[str, str] = ("toto_backbone.pt", "toto_checkpoint.json")
+
+
+CHECKPOINT_FILENAME_POLICY = CheckpointFilenamePolicy()
+
+
 def _shared_checkpoint_paths(base_dir: str, *relative_paths: str) -> tuple[str, ...]:
     """Resolve model-specific artifact names to full checkpoint paths."""
     if not relative_paths:

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -180,6 +180,36 @@ def load_pickle_checkpoint_artifact(
     return None, None
 
 
+def _shared_save_preprocessor_artifact(
+    artifact: Any,
+    *,
+    output_dir: str,
+    relative_paths: tuple[str, ...],
+    pickle_module: Any,
+) -> tuple[str, ...]:
+    """Persist preprocessor artifacts to canonical checkpoint-relative paths."""
+    resolved_paths = _shared_checkpoint_paths(output_dir, *relative_paths)
+    return save_pickle_checkpoint_artifact(
+        artifact,
+        paths=resolved_paths,
+        pickle_module=pickle_module,
+    )
+
+
+def _shared_load_preprocessor_artifact(
+    *,
+    model_dir: str,
+    relative_paths: tuple[str, ...],
+    pickle_module: Any,
+) -> tuple[Any | None, str | None]:
+    """Load the first available preprocessor artifact from checkpoint paths."""
+    resolved_paths = _shared_checkpoint_paths(model_dir, *relative_paths)
+    return load_pickle_checkpoint_artifact(
+        paths=resolved_paths,
+        pickle_module=pickle_module,
+    )
+
+
 def _relative_symlink(target: str, link: str) -> None:
     os.symlink(os.path.relpath(os.path.abspath(target), os.path.dirname(link)), link)
 

--- a/src/models/base/checkpoint_helpers.py
+++ b/src/models/base/checkpoint_helpers.py
@@ -50,6 +50,25 @@ def read_checkpoint_json(path: str) -> dict[str, Any]:
         return json.load(handle)
 
 
+def write_checkpoint_config_payload(
+    output_dir: str, filename: str, payload: dict[str, Any]
+) -> str:
+    """Write a model-specific checkpoint config payload and return its path."""
+    config_path = _shared_checkpoint_paths(output_dir, filename)[0]
+    write_checkpoint_json(config_path, payload)
+    return config_path
+
+
+def read_checkpoint_config_payload(
+    model_dir: str, filename: str
+) -> dict[str, Any] | None:
+    """Read a model-specific checkpoint config payload when present."""
+    config_path = _shared_checkpoint_paths(model_dir, filename)[0]
+    if not os.path.exists(config_path):
+        return None
+    return read_checkpoint_json(config_path)
+
+
 def write_checkpoint_reference(
     output_dir: str,
     reference_filename: str,

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -23,11 +23,8 @@ Extracted from validated experiment script (1.890 RMSE, -26% vs zero-shot)
 and notebook 4.17-ss-chronos2-pipeline-validation.ipynb.
 """
 
-import json
 import logging
 import os
-import pickle
-import shutil
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -43,8 +40,11 @@ from ..autogluon_data_utils import (
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
     CHECKPOINT_PATH_KEY,
+    build_chronos2_shadow_predictor_snapshot,
+    list_intermediate_checkpoint_adapters,
     resolve_checkpoint_reference,
     write_checkpoint_reference,
+    write_snapshot_model_pt_bundle,
 )
 from ..base.registry import ModelRegistry
 from .config import Chronos2Config
@@ -287,7 +287,10 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
             info_print("No W0 dir found, skipping checkpoint materialisation")
             return
 
-        checkpoints = self._list_intermediate_checkpoints(w0_dir)
+        checkpoints = list_intermediate_checkpoint_adapters(
+            w0_dir,
+            log_fn=info_print,
+        )
 
         if not checkpoints:
             info_print("No intermediate checkpoints found to materialise")
@@ -303,132 +306,23 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
                 continue
 
             shadow_predictor = os.path.join(snapshot_dir, "predictor")
-            self._build_shadow_predictor_snapshot(
+            build_chronos2_shadow_predictor_snapshot(
                 output_dir=output_dir,
                 w0_dir=w0_dir,
                 adapter_src=adapter_src,
                 shadow_predictor=shadow_predictor,
             )
-            snapshot_model_pt = self._write_snapshot_model_pt(
+            snapshot_model_pt = write_snapshot_model_pt_bundle(
                 snapshot_dir=snapshot_dir,
                 main_model_pt=main_model_pt,
+                predictor_reference_filename=self._PREDICTOR_JSON_NAME,
+                predictor_target_path="../predictor",
+                config_payload=self.config.to_dict(),
             )
 
             info_print(f"  Snapshot step_{step_num} → {snapshot_model_pt}")
 
         info_print(f"Intermediate checkpoints materialised at {snapshots_base}")
-
-    @staticmethod
-    def _rel_symlink(target: str, link: str) -> None:
-        os.symlink(
-            os.path.relpath(os.path.abspath(target), os.path.dirname(link)), link
-        )
-
-    def _list_intermediate_checkpoints(self, w0_dir: str) -> List[Tuple[str, int, str]]:
-        checkpoints = sorted(
-            [
-                d
-                for d in os.listdir(w0_dir)
-                if d.startswith("checkpoint-")
-                and os.path.isdir(os.path.join(w0_dir, d))
-            ],
-            key=lambda x: int(x.split("-")[1]),
-        )
-        materializable: List[Tuple[str, int, str]] = []
-        for ckpt_name in checkpoints:
-            step_num = int(ckpt_name.split("-")[1])
-            adapter_src = os.path.join(w0_dir, ckpt_name, "adapter_model.safetensors")
-            if not os.path.exists(adapter_src):
-                info_print(f"  {ckpt_name}: no adapter_model.safetensors, skipping")
-                continue
-            materializable.append((ckpt_name, step_num, adapter_src))
-        return materializable
-
-    def _build_shadow_predictor_snapshot(
-        self,
-        *,
-        output_dir: str,
-        w0_dir: str,
-        adapter_src: str,
-        shadow_predictor: str,
-    ) -> None:
-        os.makedirs(shadow_predictor, exist_ok=True)
-        for entry in os.listdir(output_dir):
-            if entry in ("models", "snapshots"):
-                continue
-            self._rel_symlink(
-                os.path.join(output_dir, entry),
-                os.path.join(shadow_predictor, entry),
-            )
-
-        models_orig = os.path.join(output_dir, "models")
-        shadow_models = os.path.join(shadow_predictor, "models")
-        os.makedirs(shadow_models, exist_ok=True)
-        for entry in os.listdir(models_orig):
-            if entry == "Chronos2":
-                continue
-            self._rel_symlink(
-                os.path.join(models_orig, entry),
-                os.path.join(shadow_models, entry),
-            )
-
-        shadow_c2 = os.path.join(shadow_models, "Chronos2")
-        os.makedirs(shadow_c2, exist_ok=True)
-        c2_orig = os.path.join(models_orig, "Chronos2")
-        for entry in os.listdir(c2_orig):
-            if entry == "W0":
-                continue
-            self._rel_symlink(
-                os.path.join(c2_orig, entry),
-                os.path.join(shadow_c2, entry),
-            )
-
-        shadow_w0 = os.path.join(shadow_c2, "W0")
-        os.makedirs(shadow_w0, exist_ok=True)
-        for entry in os.listdir(w0_dir):
-            if entry == "fine-tuned-ckpt" or entry.startswith("checkpoint-"):
-                continue
-            if entry == "model.pkl":
-                with open(os.path.join(w0_dir, "model.pkl"), "rb") as model_file:
-                    w0_model = pickle.load(model_file)
-                w0_model.path = os.path.abspath(shadow_w0)
-                with open(os.path.join(shadow_w0, "model.pkl"), "wb") as model_file:
-                    pickle.dump(w0_model, model_file)
-                continue
-            self._rel_symlink(
-                os.path.join(w0_dir, entry),
-                os.path.join(shadow_w0, entry),
-            )
-
-        orig_ft_ckpt = os.path.join(w0_dir, "fine-tuned-ckpt")
-        shadow_ft_ckpt = os.path.join(shadow_w0, "fine-tuned-ckpt")
-        os.makedirs(shadow_ft_ckpt, exist_ok=True)
-        for entry in os.listdir(orig_ft_ckpt):
-            if entry == "adapter_model.safetensors":
-                continue
-            self._rel_symlink(
-                os.path.join(orig_ft_ckpt, entry),
-                os.path.join(shadow_ft_ckpt, entry),
-            )
-        shutil.copy2(
-            adapter_src,
-            os.path.join(shadow_ft_ckpt, "adapter_model.safetensors"),
-        )
-
-    def _write_snapshot_model_pt(self, *, snapshot_dir: str, main_model_pt: str) -> str:
-        snapshot_model_pt = os.path.join(snapshot_dir, "model.pt")
-        os.makedirs(snapshot_model_pt, exist_ok=True)
-        write_checkpoint_reference(
-            output_dir=snapshot_model_pt,
-            reference_filename=self._PREDICTOR_JSON_NAME,
-            target_path="../predictor",
-        )
-        with open(os.path.join(snapshot_model_pt, "config.json"), "w") as f:
-            json.dump(self.config.to_dict(), f, indent=2)
-        meta_src = os.path.join(main_model_pt, "metadata.json")
-        if os.path.exists(meta_src):
-            shutil.copy2(meta_src, os.path.join(snapshot_model_pt, "metadata.json"))
-        return snapshot_model_pt
 
     # ------------------------------------------------------------------
     # Inference helpers

--- a/src/models/chronos2/model.py
+++ b/src/models/chronos2/model.py
@@ -42,6 +42,7 @@ from ..autogluon_data_utils import (
 )
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
+    CHECKPOINT_PATH_KEY,
     resolve_checkpoint_reference,
     write_checkpoint_reference,
 )
@@ -248,7 +249,10 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
             self._materialize_intermediate_checkpoints(output_dir)
 
         return {
-            "train_metrics": {"status": "completed", "predictor_path": predictor.path}
+            "train_metrics": {
+                CHECKPOINT_PATH_KEY: predictor.path,
+                "status": "completed",
+            }
         }
 
     # ------------------------------------------------------------------
@@ -414,8 +418,11 @@ class Chronos2Forecaster(BaseTimeSeriesFoundationModel):
     def _write_snapshot_model_pt(self, *, snapshot_dir: str, main_model_pt: str) -> str:
         snapshot_model_pt = os.path.join(snapshot_dir, "model.pt")
         os.makedirs(snapshot_model_pt, exist_ok=True)
-        with open(os.path.join(snapshot_model_pt, "chronos2_predictor.json"), "w") as f:
-            json.dump({"predictor_path": "../predictor"}, f, indent=2)
+        write_checkpoint_reference(
+            output_dir=snapshot_model_pt,
+            reference_filename=self._PREDICTOR_JSON_NAME,
+            target_path="../predictor",
+        )
         with open(os.path.join(snapshot_model_pt, "config.json"), "w") as f:
             json.dump(self.config.to_dict(), f, indent=2)
         meta_src = os.path.join(main_model_pt, "metadata.json")

--- a/src/models/moment/model.py
+++ b/src/models/moment/model.py
@@ -661,17 +661,12 @@ class MomentForecaster(BaseTimeSeriesFoundationModel):
 
         return train_loader, val_loader, test_loader
 
-    def _predict_batch(
+    def _validate_predict_batch_request(
         self,
         data: pd.DataFrame,
         episode_col: str,
-        quantile_levels: Optional[List[float]] = None,
-    ) -> Dict[str, np.ndarray]:
-        """Native batched multi-episode prediction.
-
-        Builds one context window per episode and runs batched inference in
-        chunks to reduce GPU launch overhead versus per-episode predict() calls.
-        """
+        quantile_levels: Optional[List[float]],
+    ) -> None:
         if quantile_levels is not None:
             raise NotImplementedError(
                 "MomentForecaster does not support probabilistic forecasts."
@@ -684,6 +679,12 @@ class MomentForecaster(BaseTimeSeriesFoundationModel):
                 f"Available columns: {list(data.columns)}"
             )
 
+    def _collect_episode_contexts(
+        self,
+        data: pd.DataFrame,
+        *,
+        episode_col: str,
+    ) -> Tuple[List[str], List[np.ndarray], List[int]]:
         episode_ids: List[str] = []
         contexts: List[np.ndarray] = []
         context_lens: List[int] = []
@@ -701,21 +702,35 @@ class MomentForecaster(BaseTimeSeriesFoundationModel):
             contexts.append(mat)
             context_lens.append(len(mat))
 
-        if not contexts:
-            return {}
+        return episode_ids, contexts, context_lens
 
+    @staticmethod
+    def _pad_batch_contexts(
+        contexts: List[np.ndarray],
+        context_lens: List[int],
+    ) -> np.ndarray:
         max_ctx = max(context_lens)
         n_channels = contexts[0].shape[1]
         ctx_padded = np.zeros((len(contexts), max_ctx, n_channels), dtype=np.float32)
         for i, ctx in enumerate(contexts):
             ctx_padded[i, -len(ctx) :, :] = ctx
+        return ctx_padded
 
-        bs = int(getattr(self.config, "batch_size", len(contexts)) or len(contexts))
-        bs = max(1, bs)
+    def _forecast_episode_batches(
+        self,
+        *,
+        episode_ids: List[str],
+        ctx_padded: np.ndarray,
+        context_lens: List[int],
+    ) -> Dict[str, np.ndarray]:
+        batch_size = int(
+            getattr(self.config, "batch_size", len(episode_ids)) or len(episode_ids)
+        )
+        batch_size = max(1, batch_size)
         results: Dict[str, np.ndarray] = {}
 
-        for start in range(0, len(contexts), bs):
-            end = min(start + bs, len(contexts))
+        for start in range(0, len(episode_ids), batch_size):
+            end = min(start + batch_size, len(episode_ids))
             batch_preds = self._forecast_batch(
                 ctx_padded[start:end],
                 prediction_length=self.config.forecast_length,
@@ -725,6 +740,32 @@ class MomentForecaster(BaseTimeSeriesFoundationModel):
                 results[ep_id] = batch_preds[i]
 
         return results
+
+    def _predict_batch(
+        self,
+        data: pd.DataFrame,
+        episode_col: str,
+        quantile_levels: Optional[List[float]] = None,
+    ) -> Dict[str, np.ndarray]:
+        """Native batched multi-episode prediction.
+
+        Builds one context window per episode and runs batched inference in
+        chunks to reduce GPU launch overhead versus per-episode predict() calls.
+        """
+        self._validate_predict_batch_request(data, episode_col, quantile_levels)
+        episode_ids, contexts, context_lens = self._collect_episode_contexts(
+            data, episode_col=episode_col
+        )
+
+        if not contexts:
+            return {}
+
+        ctx_padded = self._pad_batch_contexts(contexts, context_lens)
+        return self._forecast_episode_batches(
+            episode_ids=episode_ids,
+            ctx_padded=ctx_padded,
+            context_lens=context_lens,
+        )
 
     # --- Checkpoints ---
     def _save_checkpoint(self, output_dir: str) -> None:

--- a/src/models/tide/model.py
+++ b/src/models/tide/model.py
@@ -32,6 +32,7 @@ from ..autogluon_data_utils import (
 )
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
+    CHECKPOINT_PATH_KEY,
     resolve_checkpoint_reference,
     write_checkpoint_reference,
 )
@@ -206,7 +207,10 @@ class TiDEForecaster(BaseTimeSeriesFoundationModel):
 
         info_print(f"Training complete. Predictor saved to {predictor.path}")
         return {
-            "train_metrics": {"status": "completed", "predictor_path": predictor.path}
+            "train_metrics": {
+                CHECKPOINT_PATH_KEY: predictor.path,
+                "status": "completed",
+            }
         }
 
     # ------------------------------------------------------------------

--- a/src/models/timesfm/model.py
+++ b/src/models/timesfm/model.py
@@ -18,6 +18,7 @@ from transformers import TrainerCallback as _TrainerCallbackBase
 from ...utils.logging_helper import error_print, info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
+    CHECKPOINT_FILENAME_POLICY,
     _shared_checkpoint_paths,
     read_checkpoint_config_payload,
     write_checkpoint_config_payload,
@@ -1220,14 +1221,18 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
         }
 
     def _load_saved_checkpoint_config(self, model_dir: str) -> None:
-        saved_config = read_checkpoint_config_payload(model_dir, "timesfm_config.json")
+        saved_config = read_checkpoint_config_payload(
+            model_dir, CHECKPOINT_FILENAME_POLICY.timesfm_artifacts[1]
+        )
         if saved_config is None:
             return
 
         if saved_config.get("checkpoint_path"):
             self.config.checkpoint_path = saved_config["checkpoint_path"]
 
-        config_path = _shared_checkpoint_paths(model_dir, "timesfm_config.json")[0]
+        config_path = _shared_checkpoint_paths(
+            model_dir, CHECKPOINT_FILENAME_POLICY.timesfm_artifacts[1]
+        )[0]
         info_print(f"TimesFM config loaded from {config_path}")
 
     def _load_hf_model_weights(self, hf_model_dir: str) -> bool:
@@ -1252,8 +1257,7 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
         os.makedirs(output_dir, exist_ok=True)
         hf_model_dir, timesfm_config_path = _shared_checkpoint_paths(
             output_dir,
-            "hf_model",
-            "timesfm_config.json",
+            *CHECKPOINT_FILENAME_POLICY.timesfm_artifacts,
         )
 
         # Save HF model weights + config
@@ -1263,7 +1267,7 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
 
         write_checkpoint_config_payload(
             output_dir,
-            "timesfm_config.json",
+            CHECKPOINT_FILENAME_POLICY.timesfm_artifacts[1],
             self._checkpoint_config_payload(),
         )
         info_print(f"TimesFM config saved to {timesfm_config_path}")
@@ -1272,8 +1276,7 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
         """Load model checkpoint from HF save_pretrained format."""
         hf_model_dir, timesfm_config_path = _shared_checkpoint_paths(
             model_dir,
-            "hf_model",
-            "timesfm_config.json",
+            *CHECKPOINT_FILENAME_POLICY.timesfm_artifacts,
         )
         self._load_saved_checkpoint_config(model_dir)
 

--- a/src/models/timesfm/model.py
+++ b/src/models/timesfm/model.py
@@ -18,6 +18,7 @@ from transformers import TrainerCallback as _TrainerCallbackBase
 
 from ...utils.logging_helper import error_print, info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
+from ..base.checkpoint_helpers import _shared_checkpoint_paths
 from ..base.registry import ModelRegistry
 from .config import TimesFMConfig
 
@@ -1206,13 +1207,6 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
 
         return {"training_history": trainer.state.log_history}
 
-    @staticmethod
-    def _checkpoint_paths(base_dir: str) -> tuple[str, str]:
-        return (
-            os.path.join(base_dir, "hf_model"),
-            os.path.join(base_dir, "timesfm_config.json"),
-        )
-
     def _checkpoint_config_payload(self) -> Dict[str, Any]:
         return {
             "checkpoint_path": self.config.checkpoint_path,
@@ -1258,7 +1252,11 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
     def _save_checkpoint(self, output_dir: str) -> None:
         """Save checkpoint. Uses 'hf_model/' subdir to avoid config.json conflicts."""
         os.makedirs(output_dir, exist_ok=True)
-        hf_model_dir, timesfm_config_path = self._checkpoint_paths(output_dir)
+        hf_model_dir, timesfm_config_path = _shared_checkpoint_paths(
+            output_dir,
+            "hf_model",
+            "timesfm_config.json",
+        )
 
         # Save HF model weights + config
         if self.hf_model is not None:
@@ -1270,7 +1268,11 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
 
     def _load_checkpoint(self, model_dir: str) -> None:
         """Load model checkpoint from HF save_pretrained format."""
-        hf_model_dir, timesfm_config_path = self._checkpoint_paths(model_dir)
+        hf_model_dir, timesfm_config_path = _shared_checkpoint_paths(
+            model_dir,
+            "hf_model",
+            "timesfm_config.json",
+        )
         self._load_saved_checkpoint_config(timesfm_config_path)
 
         if not self._load_hf_model_weights(hf_model_dir):

--- a/src/models/timesfm/model.py
+++ b/src/models/timesfm/model.py
@@ -1274,7 +1274,7 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
 
     def _load_checkpoint(self, model_dir: str) -> None:
         """Load model checkpoint from HF save_pretrained format."""
-        hf_model_dir, timesfm_config_path = _shared_checkpoint_paths(
+        hf_model_dir, _ = _shared_checkpoint_paths(
             model_dir,
             *CHECKPOINT_FILENAME_POLICY.timesfm_artifacts,
         )

--- a/src/models/timesfm/model.py
+++ b/src/models/timesfm/model.py
@@ -4,7 +4,6 @@ Supports zero-shot inference and fine-tuning with per-window normalized loss.
 """
 
 import contextlib
-import json
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, cast
@@ -18,7 +17,11 @@ from transformers import TrainerCallback as _TrainerCallbackBase
 
 from ...utils.logging_helper import error_print, info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
-from ..base.checkpoint_helpers import _shared_checkpoint_paths
+from ..base.checkpoint_helpers import (
+    _shared_checkpoint_paths,
+    read_checkpoint_config_payload,
+    write_checkpoint_config_payload,
+)
 from ..base.registry import ModelRegistry
 from .config import TimesFMConfig
 
@@ -1216,20 +1219,15 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
             "is_finetuned": self.is_fitted,
         }
 
-    def _write_checkpoint_config(self, config_path: str) -> None:
-        with open(config_path, "w") as f:
-            json.dump(self._checkpoint_config_payload(), f, indent=2)
-
-    def _load_saved_checkpoint_config(self, config_path: str) -> None:
-        if not os.path.exists(config_path):
+    def _load_saved_checkpoint_config(self, model_dir: str) -> None:
+        saved_config = read_checkpoint_config_payload(model_dir, "timesfm_config.json")
+        if saved_config is None:
             return
-
-        with open(config_path, "r") as f:
-            saved_config = json.load(f)
 
         if saved_config.get("checkpoint_path"):
             self.config.checkpoint_path = saved_config["checkpoint_path"]
 
+        config_path = _shared_checkpoint_paths(model_dir, "timesfm_config.json")[0]
         info_print(f"TimesFM config loaded from {config_path}")
 
     def _load_hf_model_weights(self, hf_model_dir: str) -> bool:
@@ -1263,7 +1261,11 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
             self.hf_model.save_pretrained(hf_model_dir)
             info_print(f"HF model saved to {hf_model_dir}")
 
-        self._write_checkpoint_config(timesfm_config_path)
+        write_checkpoint_config_payload(
+            output_dir,
+            "timesfm_config.json",
+            self._checkpoint_config_payload(),
+        )
         info_print(f"TimesFM config saved to {timesfm_config_path}")
 
     def _load_checkpoint(self, model_dir: str) -> None:
@@ -1273,7 +1275,7 @@ class TimesFMForecaster(BaseTimeSeriesFoundationModel):
             "hf_model",
             "timesfm_config.json",
         )
-        self._load_saved_checkpoint_config(timesfm_config_path)
+        self._load_saved_checkpoint_config(model_dir)
 
         if not self._load_hf_model_weights(hf_model_dir):
             info_print(

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -2,7 +2,6 @@
 Toto model implementation using the base TSFM framework.
 """
 
-import json
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
@@ -20,7 +19,11 @@ from toto.model.toto import Toto  # pyright: ignore[reportMissingImports]
 
 from ...utils.logging_helper import info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
-from ..base.checkpoint_helpers import _shared_checkpoint_paths
+from ..base.checkpoint_helpers import (
+    _shared_checkpoint_paths,
+    read_checkpoint_config_payload,
+    write_checkpoint_config_payload,
+)
 from ..base.registry import ModelRegistry
 from .config import TotoConfig
 
@@ -609,8 +612,11 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         )
         torch.save(self.model.state_dict(), weights_path)
 
-        with open(ref_path, "w") as f:
-            json.dump({"weights_file": "toto_backbone.pt"}, f, indent=2)
+        write_checkpoint_config_payload(
+            output_dir,
+            "toto_checkpoint.json",
+            {"weights_file": "toto_backbone.pt"},
+        )
 
         logger.info("Toto checkpoint saved to %s", output_dir)
 
@@ -624,9 +630,8 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             "toto_checkpoint.json",
             "toto_backbone.pt",
         )
-        if os.path.exists(ref_path):
-            with open(ref_path) as f:
-                ref = json.load(f)
+        ref = read_checkpoint_config_payload(model_dir, "toto_checkpoint.json")
+        if ref is not None:
             weights_path = _shared_checkpoint_paths(model_dir, ref["weights_file"])[0]
         else:
             # Fall back to looking for the weights file directly

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -607,7 +607,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             return
 
         os.makedirs(output_dir, exist_ok=True)
-        weights_path, ref_path = _shared_checkpoint_paths(
+        weights_path, _ = _shared_checkpoint_paths(
             output_dir,
             *CHECKPOINT_FILENAME_POLICY.toto_artifacts,
         )
@@ -626,7 +626,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
 
         Loads the backbone state dict saved by _save_checkpoint.
         """
-        ref_path, fallback_weights_path = _shared_checkpoint_paths(
+        _, fallback_weights_path = _shared_checkpoint_paths(
             model_dir,
             CHECKPOINT_FILENAME_POLICY.toto_artifacts[1],
             CHECKPOINT_FILENAME_POLICY.toto_artifacts[0],

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -20,6 +20,7 @@ from toto.model.toto import Toto  # pyright: ignore[reportMissingImports]
 
 from ...utils.logging_helper import info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
+from ..base.checkpoint_helpers import _shared_checkpoint_paths
 from ..base.registry import ModelRegistry
 from .config import TotoConfig
 
@@ -601,10 +602,13 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             return
 
         os.makedirs(output_dir, exist_ok=True)
-        weights_path = os.path.join(output_dir, "toto_backbone.pt")
+        weights_path, ref_path = _shared_checkpoint_paths(
+            output_dir,
+            "toto_backbone.pt",
+            "toto_checkpoint.json",
+        )
         torch.save(self.model.state_dict(), weights_path)
 
-        ref_path = os.path.join(output_dir, "toto_checkpoint.json")
         with open(ref_path, "w") as f:
             json.dump({"weights_file": "toto_backbone.pt"}, f, indent=2)
 
@@ -615,14 +619,18 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
 
         Loads the backbone state dict saved by _save_checkpoint.
         """
-        ref_path = os.path.join(model_dir, "toto_checkpoint.json")
+        ref_path, fallback_weights_path = _shared_checkpoint_paths(
+            model_dir,
+            "toto_checkpoint.json",
+            "toto_backbone.pt",
+        )
         if os.path.exists(ref_path):
             with open(ref_path) as f:
                 ref = json.load(f)
-            weights_path = os.path.join(model_dir, ref["weights_file"])
+            weights_path = _shared_checkpoint_paths(model_dir, ref["weights_file"])[0]
         else:
             # Fall back to looking for the weights file directly
-            weights_path = os.path.join(model_dir, "toto_backbone.pt")
+            weights_path = fallback_weights_path
 
         if not os.path.exists(weights_path):
             raise FileNotFoundError(f"Toto checkpoint not found at {weights_path}")

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -20,6 +20,7 @@ from toto.model.toto import Toto  # pyright: ignore[reportMissingImports]
 from ...utils.logging_helper import info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
+    CHECKPOINT_FILENAME_POLICY,
     _shared_checkpoint_paths,
     read_checkpoint_config_payload,
     write_checkpoint_config_payload,
@@ -607,15 +608,14 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         os.makedirs(output_dir, exist_ok=True)
         weights_path, ref_path = _shared_checkpoint_paths(
             output_dir,
-            "toto_backbone.pt",
-            "toto_checkpoint.json",
+            *CHECKPOINT_FILENAME_POLICY.toto_artifacts,
         )
         torch.save(self.model.state_dict(), weights_path)
 
         write_checkpoint_config_payload(
             output_dir,
-            "toto_checkpoint.json",
-            {"weights_file": "toto_backbone.pt"},
+            CHECKPOINT_FILENAME_POLICY.toto_artifacts[1],
+            {"weights_file": CHECKPOINT_FILENAME_POLICY.toto_artifacts[0]},
         )
 
         logger.info("Toto checkpoint saved to %s", output_dir)
@@ -627,10 +627,12 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         """
         ref_path, fallback_weights_path = _shared_checkpoint_paths(
             model_dir,
-            "toto_checkpoint.json",
-            "toto_backbone.pt",
+            CHECKPOINT_FILENAME_POLICY.toto_artifacts[1],
+            CHECKPOINT_FILENAME_POLICY.toto_artifacts[0],
         )
-        ref = read_checkpoint_config_payload(model_dir, "toto_checkpoint.json")
+        ref = read_checkpoint_config_payload(
+            model_dir, CHECKPOINT_FILENAME_POLICY.toto_artifacts[1]
+        )
         if ref is not None:
             weights_path = _shared_checkpoint_paths(model_dir, ref["weights_file"])[0]
         else:

--- a/src/models/toto/model.py
+++ b/src/models/toto/model.py
@@ -21,6 +21,7 @@ from ...utils.logging_helper import info_print
 from ..base import BaseTimeSeriesFoundationModel, TrainingBackend
 from ..base.checkpoint_helpers import (
     CHECKPOINT_FILENAME_POLICY,
+    CHECKPOINT_WEIGHTS_FILE_KEY,
     _shared_checkpoint_paths,
     read_checkpoint_config_payload,
     write_checkpoint_config_payload,
@@ -615,7 +616,7 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
         write_checkpoint_config_payload(
             output_dir,
             CHECKPOINT_FILENAME_POLICY.toto_artifacts[1],
-            {"weights_file": CHECKPOINT_FILENAME_POLICY.toto_artifacts[0]},
+            {CHECKPOINT_WEIGHTS_FILE_KEY: CHECKPOINT_FILENAME_POLICY.toto_artifacts[0]},
         )
 
         logger.info("Toto checkpoint saved to %s", output_dir)
@@ -634,7 +635,9 @@ class TotoForecaster(BaseTimeSeriesFoundationModel):
             model_dir, CHECKPOINT_FILENAME_POLICY.toto_artifacts[1]
         )
         if ref is not None:
-            weights_path = _shared_checkpoint_paths(model_dir, ref["weights_file"])[0]
+            weights_path = _shared_checkpoint_paths(
+                model_dir, ref[CHECKPOINT_WEIGHTS_FILE_KEY]
+            )[0]
         else:
             # Fall back to looking for the weights file directly
             weights_path = fallback_weights_path

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -33,6 +33,7 @@ from ...utils.logging_helper import debug_print, error_print, info_print
 
 # Local imports
 from ..base import BaseTimeSeriesFoundationModel, ModelConfig, TrainingBackend
+from ..base.checkpoint_helpers import _shared_checkpoint_paths
 from ..base.registry import ModelRegistry
 from .config import TTMConfig
 
@@ -851,14 +852,6 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
         )
         return pipeline, target_columns[0]
 
-    @staticmethod
-    def _preprocessor_paths(model_dir: str) -> Tuple[str, str]:
-        """Return supported preprocessor artifact locations for a checkpoint."""
-        return (
-            os.path.join(model_dir, "preprocessor.pkl"),
-            os.path.join(model_dir, "model.pt", "preprocessor.pkl"),
-        )
-
     def _save_preprocessor_checkpoint(
         self, output_dir: str, *, pickle_module: Any
     ) -> None:
@@ -870,7 +863,11 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             )
             return
 
-        root_path, model_pt_path = self._preprocessor_paths(output_dir)
+        root_path, model_pt_path = _shared_checkpoint_paths(
+            output_dir,
+            "preprocessor.pkl",
+            "model.pt/preprocessor.pkl",
+        )
         with open(root_path, "wb") as f:
             pickle_module.dump(self.preprocessor, f)
         info_print(f"Preprocessor saved to {root_path}")
@@ -885,7 +882,11 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
         self, model_dir: str, *, pickle_module: Any
     ) -> Optional[TimeSeriesPreprocessor]:
         """Load preprocessor artifact from known checkpoint locations."""
-        root_path, model_pt_path = self._preprocessor_paths(model_dir)
+        root_path, model_pt_path = _shared_checkpoint_paths(
+            model_dir,
+            "preprocessor.pkl",
+            "model.pt/preprocessor.pkl",
+        )
         for path in (root_path, model_pt_path):
             if not os.path.exists(path):
                 continue

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -548,7 +548,26 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             self.model.save_pretrained(output_dir)  # type: ignore[union-attr]
             info_print(f"TTM model saved to {output_dir}")
 
-        self._save_preprocessor_checkpoint(output_dir, pickle_module=pickle)
+        if self.preprocessor is None:
+            logger.warning(
+                "Preprocessor is None - not saved. "
+                "This will cause inference to return scaled predictions instead of original units."
+            )
+            return
+
+        root_path, model_pt_path = _shared_checkpoint_paths(
+            output_dir,
+            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
+        )
+        written_paths = save_pickle_checkpoint_artifact(
+            self.preprocessor,
+            paths=(root_path, model_pt_path),
+            pickle_module=pickle,
+        )
+        if written_paths:
+            info_print(f"Preprocessor saved to {written_paths[0]}")
+        if len(written_paths) > 1:
+            info_print(f"Preprocessor also saved to {written_paths[1]}")
 
     def _load_checkpoint(self, model_dir: str) -> None:
         """Load model checkpoint.
@@ -561,61 +580,58 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
         """
         import pickle
 
-        try:
-            # Use get_model() to load the TTM architecture from the checkpoint directory
-            # This properly handles the custom TTM model type
-            model_params = {
-                "model_path": model_dir,  # Load from checkpoint directory
-                "context_length": self.config.context_length,
-                "prediction_length": self.config.forecast_length,
-                "freq": f"{self.config.resolution_min}min",
-                "return_model_key": False,  # Ensure we get the model object, not a string
-            }
-
-            # Only add prediction_filter_length if it's not None
-            if self.config.prediction_filter_length is not None:
-                model_params["prediction_filter_length"] = (
-                    self.config.prediction_filter_length
-                )
-
-            info_print(
-                f"Loading TTM checkpoint from {model_dir} with params: {model_params}"
-            )
-            ttm_model = get_model(**model_params)
-
-            # Validate that we received a model object, not a string
-            if isinstance(ttm_model, str):
-                raise TypeError(
-                    f"Expected model object from get_model(), but received string: {ttm_model}"
-                )
-
-            self.model = ttm_model
-            info_print(f"TTM model checkpoint loaded from {model_dir}")
-
-            self.preprocessor = self._load_preprocessor_checkpoint(
-                model_dir, pickle_module=pickle
+        model_params = {
+            "model_path": model_dir,
+            "context_length": self.config.context_length,
+            "prediction_length": self.config.forecast_length,
+            "freq": f"{self.config.resolution_min}min",
+            "return_model_key": False,
+        }
+        if self.config.prediction_filter_length is not None:
+            model_params["prediction_filter_length"] = (
+                self.config.prediction_filter_length
             )
 
-            if self.preprocessor is not None:
-                _validate_preprocessor_schema(self.preprocessor)
+        info_print(
+            f"Loading TTM checkpoint from {model_dir} with params: {model_params}"
+        )
+        ttm_model = get_model(**model_params)
+        if isinstance(ttm_model, str):
+            raise TypeError(
+                f"Expected model object from get_model(), but received string: {ttm_model}"
+            )
 
-            # Only mark as fitted if the preprocessor was also successfully loaded.
-            # The fitted inference path in _predict() unconditionally dereferences
-            # self.preprocessor, so setting is_fitted=True without a preprocessor
-            # would cause an AttributeError at inference time.
-            if self.preprocessor is not None:
-                self.is_fitted = True
-                info_print("Model marked as fitted (preprocessor loaded successfully).")
-            else:
-                self.is_fitted = False
-                logger.warning(
-                    "Model checkpoint loaded but is_fitted=False: preprocessor is missing. "
-                    "Falling back to zero-shot inference path (TTM internal RevIN only)."
-                )
+        self.model = ttm_model
+        info_print(f"TTM model checkpoint loaded from {model_dir}")
 
-        except Exception as e:
-            error_print(f"Failed to load model checkpoint: {str(e)}")
-            raise
+        root_path, model_pt_path = _shared_checkpoint_paths(
+            model_dir,
+            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
+        )
+        loaded_preprocessor, loaded_path = load_pickle_checkpoint_artifact(
+            paths=(root_path, model_pt_path),
+            pickle_module=pickle,
+        )
+        if loaded_path is not None:
+            info_print(f"Preprocessor loaded from {loaded_path}")
+            self.preprocessor = cast(TimeSeriesPreprocessor, loaded_preprocessor)
+            _validate_preprocessor_schema(self.preprocessor)
+            self.is_fitted = True
+            info_print("Model marked as fitted (preprocessor loaded successfully).")
+            return
+
+        self.preprocessor = None
+        self.is_fitted = False
+        logger.warning(
+            f"No preprocessor found at {model_dir}. "
+            "Predictions will return SCALED values (z-scores) instead of original units. "
+            "This will cause incorrect metrics if comparing to unscaled ground truth. "
+            "Ensure preprocessor.pkl was saved during training."
+        )
+        logger.warning(
+            "Model checkpoint loaded but is_fitted=False: preprocessor is missing. "
+            "Falling back to zero-shot inference path (TTM internal RevIN only)."
+        )
 
     # TTM-specific private methods
     def _require_initialized_model(self) -> Any:
@@ -856,55 +872,6 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             target_columns=target_columns,
         )
         return pipeline, target_columns[0]
-
-    def _save_preprocessor_checkpoint(
-        self, output_dir: str, *, pickle_module: Any
-    ) -> None:
-        """Persist preprocessor artifacts to checkpoint-compatible locations."""
-        if self.preprocessor is None:
-            logger.warning(
-                "Preprocessor is None - not saved. "
-                "This will cause inference to return scaled predictions instead of original units."
-            )
-            return
-
-        root_path, model_pt_path = _shared_checkpoint_paths(
-            output_dir,
-            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
-        )
-        written_paths = save_pickle_checkpoint_artifact(
-            self.preprocessor,
-            paths=(root_path, model_pt_path),
-            pickle_module=pickle_module,
-        )
-        if written_paths:
-            info_print(f"Preprocessor saved to {written_paths[0]}")
-        if len(written_paths) > 1:
-            info_print(f"Preprocessor also saved to {written_paths[1]}")
-
-    def _load_preprocessor_checkpoint(
-        self, model_dir: str, *, pickle_module: Any
-    ) -> Optional[TimeSeriesPreprocessor]:
-        """Load preprocessor artifact from known checkpoint locations."""
-        root_path, model_pt_path = _shared_checkpoint_paths(
-            model_dir,
-            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
-        )
-        loaded, loaded_path = load_pickle_checkpoint_artifact(
-            paths=(root_path, model_pt_path),
-            pickle_module=pickle_module,
-        )
-        if loaded_path is not None:
-            info_print(f"Preprocessor loaded from {loaded_path}")
-            return cast(TimeSeriesPreprocessor, loaded)
-
-        logger.warning(
-            f"No preprocessor found at {model_dir}. "
-            "Predictions will return SCALED values (z-scores) instead of original units. "
-            "This will cause incorrect metrics if comparing to unscaled ground truth. "
-            "Ensure preprocessor.pkl was saved during training."
-        )
-        return None
 
     def _build_zero_shot_pipeline(
         self,

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -35,9 +35,8 @@ from ...utils.logging_helper import debug_print, error_print, info_print
 from ..base import BaseTimeSeriesFoundationModel, ModelConfig, TrainingBackend
 from ..base.checkpoint_helpers import (
     CHECKPOINT_FILENAME_POLICY,
-    _shared_checkpoint_paths,
-    load_pickle_checkpoint_artifact,
-    save_pickle_checkpoint_artifact,
+    _shared_load_preprocessor_artifact,
+    _shared_save_preprocessor_artifact,
 )
 from ..base.registry import ModelRegistry
 from .config import TTMConfig
@@ -555,13 +554,10 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             )
             return
 
-        root_path, model_pt_path = _shared_checkpoint_paths(
-            output_dir,
-            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
-        )
-        written_paths = save_pickle_checkpoint_artifact(
+        written_paths = _shared_save_preprocessor_artifact(
             self.preprocessor,
-            paths=(root_path, model_pt_path),
+            output_dir=output_dir,
+            relative_paths=CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
             pickle_module=pickle,
         )
         if written_paths:
@@ -604,12 +600,9 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
         self.model = ttm_model
         info_print(f"TTM model checkpoint loaded from {model_dir}")
 
-        root_path, model_pt_path = _shared_checkpoint_paths(
-            model_dir,
-            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
-        )
-        loaded_preprocessor, loaded_path = load_pickle_checkpoint_artifact(
-            paths=(root_path, model_pt_path),
+        loaded_preprocessor, loaded_path = _shared_load_preprocessor_artifact(
+            model_dir=model_dir,
+            relative_paths=CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
             pickle_module=pickle,
         )
         if loaded_path is not None:

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -34,6 +34,7 @@ from ...utils.logging_helper import debug_print, error_print, info_print
 # Local imports
 from ..base import BaseTimeSeriesFoundationModel, ModelConfig, TrainingBackend
 from ..base.checkpoint_helpers import (
+    CHECKPOINT_FILENAME_POLICY,
     _shared_checkpoint_paths,
     load_pickle_checkpoint_artifact,
     save_pickle_checkpoint_artifact,
@@ -869,8 +870,7 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
 
         root_path, model_pt_path = _shared_checkpoint_paths(
             output_dir,
-            "preprocessor.pkl",
-            "model.pt/preprocessor.pkl",
+            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
         )
         written_paths = save_pickle_checkpoint_artifact(
             self.preprocessor,
@@ -888,8 +888,7 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
         """Load preprocessor artifact from known checkpoint locations."""
         root_path, model_pt_path = _shared_checkpoint_paths(
             model_dir,
-            "preprocessor.pkl",
-            "model.pt/preprocessor.pkl",
+            *CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts,
         )
         loaded, loaded_path = load_pickle_checkpoint_artifact(
             paths=(root_path, model_pt_path),

--- a/src/models/ttm/model.py
+++ b/src/models/ttm/model.py
@@ -33,7 +33,11 @@ from ...utils.logging_helper import debug_print, error_print, info_print
 
 # Local imports
 from ..base import BaseTimeSeriesFoundationModel, ModelConfig, TrainingBackend
-from ..base.checkpoint_helpers import _shared_checkpoint_paths
+from ..base.checkpoint_helpers import (
+    _shared_checkpoint_paths,
+    load_pickle_checkpoint_artifact,
+    save_pickle_checkpoint_artifact,
+)
 from ..base.registry import ModelRegistry
 from .config import TTMConfig
 
@@ -868,15 +872,15 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             "preprocessor.pkl",
             "model.pt/preprocessor.pkl",
         )
-        with open(root_path, "wb") as f:
-            pickle_module.dump(self.preprocessor, f)
-        info_print(f"Preprocessor saved to {root_path}")
-
-        model_pt_dir = os.path.dirname(model_pt_path)
-        if os.path.exists(model_pt_dir):
-            with open(model_pt_path, "wb") as f:
-                pickle_module.dump(self.preprocessor, f)
-            info_print(f"Preprocessor also saved to {model_pt_path}")
+        written_paths = save_pickle_checkpoint_artifact(
+            self.preprocessor,
+            paths=(root_path, model_pt_path),
+            pickle_module=pickle_module,
+        )
+        if written_paths:
+            info_print(f"Preprocessor saved to {written_paths[0]}")
+        if len(written_paths) > 1:
+            info_print(f"Preprocessor also saved to {written_paths[1]}")
 
     def _load_preprocessor_checkpoint(
         self, model_dir: str, *, pickle_module: Any
@@ -887,13 +891,13 @@ class TTMForecaster(BaseTimeSeriesFoundationModel):
             "preprocessor.pkl",
             "model.pt/preprocessor.pkl",
         )
-        for path in (root_path, model_pt_path):
-            if not os.path.exists(path):
-                continue
-            with open(path, "rb") as f:
-                loaded = cast(TimeSeriesPreprocessor, pickle_module.load(f))
-            info_print(f"Preprocessor loaded from {path}")
-            return loaded
+        loaded, loaded_path = load_pickle_checkpoint_artifact(
+            paths=(root_path, model_pt_path),
+            pickle_module=pickle_module,
+        )
+        if loaded_path is not None:
+            info_print(f"Preprocessor loaded from {loaded_path}")
+            return cast(TimeSeriesPreprocessor, loaded)
 
         logger.warning(
             f"No preprocessor found at {model_dir}. "

--- a/tests/models/test_autogluon_base.py
+++ b/tests/models/test_autogluon_base.py
@@ -18,6 +18,7 @@ import pytest
 
 pytest.importorskip("autogluon.timeseries")
 
+from src.models.base.checkpoint_helpers import CHECKPOINT_PATH_KEY  # noqa: E402
 from src.models.naive_baseline import (  # noqa: E402
     NaiveBaselineConfig,
     NaiveBaselineForecaster,
@@ -138,7 +139,7 @@ class TestAutoGluonBaseModel:
             assert os.path.exists(json_path)
             with open(json_path) as f:
                 data = json.load(f)
-            assert "predictor_path" in data
+            assert CHECKPOINT_PATH_KEY in data
 
             # Load into a fresh model
             model2 = NaiveBaselineForecaster(cfg)

--- a/tests/models/test_checkpoint_helpers.py
+++ b/tests/models/test_checkpoint_helpers.py
@@ -9,6 +9,9 @@ from src.models.base.checkpoint_helpers import (
     CHECKPOINT_FILENAME_POLICY,
     CHECKPOINT_WEIGHTS_FILE_KEY,
     _shared_checkpoint_paths,
+    _shared_load_checkpoint_bundle,
+    _shared_save_checkpoint_bundle,
+    list_intermediate_checkpoint_adapters,
     load_pickle_checkpoint_artifact,
     read_checkpoint_config_payload,
     save_pickle_checkpoint_artifact,
@@ -79,3 +82,46 @@ def test_save_pickle_checkpoint_artifact_writes_secondary_when_parent_exists(
         {"x": 1}, paths=(primary, secondary), pickle_module=pickle
     )
     assert written == (primary, secondary)
+
+
+def test_shared_checkpoint_bundle_round_trip_and_metadata_fallback(
+    tmp_path: Path,
+) -> None:
+    _shared_save_checkpoint_bundle(
+        str(tmp_path),
+        config_payload={"model_type": "stub"},
+        training_metadata_payload={"metrics": {"loss": 1.0}},
+    )
+    bundle = _shared_load_checkpoint_bundle(str(tmp_path))
+    assert bundle.config == {"model_type": "stub"}
+    assert bundle.metadata == {"metrics": {"loss": 1.0}}
+    assert bundle.metadata_path == str(tmp_path / "training_metadata.json")
+
+    _shared_save_checkpoint_bundle(
+        str(tmp_path),
+        metadata_payload={"is_fitted": True},
+    )
+    bundle = _shared_load_checkpoint_bundle(str(tmp_path))
+    assert bundle.metadata == {"is_fitted": True}
+    assert bundle.metadata_path == str(tmp_path / "metadata.json")
+
+
+def test_list_intermediate_checkpoint_adapters_filters_missing(tmp_path: Path) -> None:
+    w0_dir = tmp_path / "W0"
+    w0_dir.mkdir()
+    good = w0_dir / "checkpoint-1000"
+    bad = w0_dir / "checkpoint-2000"
+    good.mkdir()
+    bad.mkdir()
+    (good / "adapter_model.safetensors").write_text("ok")
+
+    logs: list[str] = []
+    checkpoints = list_intermediate_checkpoint_adapters(str(w0_dir), log_fn=logs.append)
+    assert checkpoints == [
+        (
+            "checkpoint-1000",
+            1000,
+            str(good / "adapter_model.safetensors"),
+        )
+    ]
+    assert logs == ["  checkpoint-2000: no adapter_model.safetensors, skipping"]

--- a/tests/models/test_checkpoint_helpers.py
+++ b/tests/models/test_checkpoint_helpers.py
@@ -10,7 +10,9 @@ from src.models.base.checkpoint_helpers import (
     CHECKPOINT_WEIGHTS_FILE_KEY,
     _shared_checkpoint_paths,
     _shared_load_checkpoint_bundle,
+    _shared_load_preprocessor_artifact,
     _shared_save_checkpoint_bundle,
+    _shared_save_preprocessor_artifact,
     list_intermediate_checkpoint_adapters,
     load_pickle_checkpoint_artifact,
     read_checkpoint_config_payload,
@@ -68,6 +70,25 @@ def test_save_and_load_pickle_checkpoint_artifact_prefers_first_available_path(
     )
     assert loaded == artifact
     assert loaded_path == primary
+
+
+def test_shared_preprocessor_artifact_round_trip(tmp_path: Path) -> None:
+    artifact = {"scaled": [1.0, 2.0]}
+    written = _shared_save_preprocessor_artifact(
+        artifact,
+        output_dir=str(tmp_path),
+        relative_paths=("preprocessor.pkl", "model.pt/preprocessor.pkl"),
+        pickle_module=pickle,
+    )
+    assert written == (str(tmp_path / "preprocessor.pkl"),)
+
+    loaded, loaded_path = _shared_load_preprocessor_artifact(
+        model_dir=str(tmp_path),
+        relative_paths=("preprocessor.pkl", "model.pt/preprocessor.pkl"),
+        pickle_module=pickle,
+    )
+    assert loaded == artifact
+    assert loaded_path == str(tmp_path / "preprocessor.pkl")
 
 
 def test_save_pickle_checkpoint_artifact_writes_secondary_when_parent_exists(

--- a/tests/models/test_checkpoint_helpers.py
+++ b/tests/models/test_checkpoint_helpers.py
@@ -1,0 +1,64 @@
+"""Unit tests for shared checkpoint helper utilities."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+from src.models.base.checkpoint_helpers import (
+    _shared_checkpoint_paths,
+    load_pickle_checkpoint_artifact,
+    read_checkpoint_config_payload,
+    save_pickle_checkpoint_artifact,
+    write_checkpoint_config_payload,
+)
+
+
+def test_shared_checkpoint_paths_resolves_relative_artifacts(tmp_path: Path) -> None:
+    first, second = _shared_checkpoint_paths(
+        str(tmp_path), "first.bin", "nested/second.bin"
+    )
+    assert first == str(tmp_path / "first.bin")
+    assert second == str(tmp_path / "nested" / "second.bin")
+
+
+def test_checkpoint_config_payload_round_trip(tmp_path: Path) -> None:
+    payload = {"weights_file": "weights.pt", "is_finetuned": True}
+    written_path = write_checkpoint_config_payload(
+        str(tmp_path), "payload.json", payload
+    )
+    assert written_path == str(tmp_path / "payload.json")
+    assert read_checkpoint_config_payload(str(tmp_path), "payload.json") == payload
+
+
+def test_save_and_load_pickle_checkpoint_artifact_prefers_first_available_path(
+    tmp_path: Path,
+) -> None:
+    primary, secondary = _shared_checkpoint_paths(
+        str(tmp_path), "preprocessor.pkl", "model.pt/preprocessor.pkl"
+    )
+    artifact = {"key": "value"}
+    written = save_pickle_checkpoint_artifact(
+        artifact, paths=(primary, secondary), pickle_module=pickle
+    )
+
+    assert written == (primary,)
+    loaded, loaded_path = load_pickle_checkpoint_artifact(
+        paths=(primary, secondary), pickle_module=pickle
+    )
+    assert loaded == artifact
+    assert loaded_path == primary
+
+
+def test_save_pickle_checkpoint_artifact_writes_secondary_when_parent_exists(
+    tmp_path: Path,
+) -> None:
+    nested_dir = tmp_path / "model.pt"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    primary, secondary = _shared_checkpoint_paths(
+        str(tmp_path), "preprocessor.pkl", "model.pt/preprocessor.pkl"
+    )
+    written = save_pickle_checkpoint_artifact(
+        {"x": 1}, paths=(primary, secondary), pickle_module=pickle
+    )
+    assert written == (primary, secondary)

--- a/tests/models/test_checkpoint_helpers.py
+++ b/tests/models/test_checkpoint_helpers.py
@@ -6,12 +6,28 @@ import pickle
 from pathlib import Path
 
 from src.models.base.checkpoint_helpers import (
+    CHECKPOINT_FILENAME_POLICY,
     _shared_checkpoint_paths,
     load_pickle_checkpoint_artifact,
     read_checkpoint_config_payload,
     save_pickle_checkpoint_artifact,
     write_checkpoint_config_payload,
 )
+
+
+def test_checkpoint_filename_policy_constants_are_stable() -> None:
+    assert CHECKPOINT_FILENAME_POLICY.ttm_preprocessor_artifacts == (
+        "preprocessor.pkl",
+        "model.pt/preprocessor.pkl",
+    )
+    assert CHECKPOINT_FILENAME_POLICY.timesfm_artifacts == (
+        "hf_model",
+        "timesfm_config.json",
+    )
+    assert CHECKPOINT_FILENAME_POLICY.toto_artifacts == (
+        "toto_backbone.pt",
+        "toto_checkpoint.json",
+    )
 
 
 def test_shared_checkpoint_paths_resolves_relative_artifacts(tmp_path: Path) -> None:

--- a/tests/models/test_checkpoint_helpers.py
+++ b/tests/models/test_checkpoint_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from src.models.base.checkpoint_helpers import (
     CHECKPOINT_FILENAME_POLICY,
+    CHECKPOINT_WEIGHTS_FILE_KEY,
     _shared_checkpoint_paths,
     load_pickle_checkpoint_artifact,
     read_checkpoint_config_payload,
@@ -39,7 +40,7 @@ def test_shared_checkpoint_paths_resolves_relative_artifacts(tmp_path: Path) -> 
 
 
 def test_checkpoint_config_payload_round_trip(tmp_path: Path) -> None:
-    payload = {"weights_file": "weights.pt", "is_finetuned": True}
+    payload = {CHECKPOINT_WEIGHTS_FILE_KEY: "weights.pt", "is_finetuned": True}
     written_path = write_checkpoint_config_payload(
         str(tmp_path), "payload.json", payload
     )

--- a/tests/models/test_chronos2_runtime_helpers.py
+++ b/tests/models/test_chronos2_runtime_helpers.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from src.models.base.checkpoint_helpers import CHECKPOINT_PATH_KEY
 from src.models.chronos2.config import (  # pyright: ignore[reportMissingImports]
     Chronos2Config,
 )
@@ -50,7 +51,7 @@ def test_materialize_intermediate_checkpoints_creates_snapshot_tree(tmp_path):
 
     assert snapshot_model_pt.exists()
     assert json.loads((snapshot_model_pt / "chronos2_predictor.json").read_text()) == {
-        "predictor_path": "../predictor"
+        CHECKPOINT_PATH_KEY: "../predictor"
     }
     assert (snapshot_model_pt / "config.json").exists()
     assert (snapshot_model_pt / "metadata.json").exists()


### PR DESCRIPTION
## Summary
Final WS1/MC1 closeout for P1-38 checkpoint/lifecycle helper extraction, with reproducible tracking metrics and post-refactor smoke parity.

## What changed

### 1) Shared checkpoint helper consolidation
- Expanded [`src/models/base/checkpoint_helpers.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/base/checkpoint_helpers.py) with:
  - shared path/key policy (`CHECKPOINT_PATH_KEY`, `CHECKPOINT_WEIGHTS_FILE_KEY`, `CHECKPOINT_FILENAME_POLICY`),
  - shared checkpoint payload I/O,
  - shared preprocessor artifact wrappers,
  - shared bundle save/load helpers (`_shared_save_checkpoint_bundle`, `_shared_load_checkpoint_bundle`),
  - shared Chronos2 intermediate snapshot materialization helpers.

### 2) Model wiring updates (behavior-preserving)
- Rewired checkpoint usage in:
  - [`src/models/ttm/model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/ttm/model.py)
  - [`src/models/timesfm/model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/timesfm/model.py)
  - [`src/models/toto/model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/toto/model.py)
  - [`src/models/chronos2/model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/chronos2/model.py)
  - [`src/models/tide/model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/tide/model.py)
  - [`src/models/autogluon_base.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/autogluon_base.py)
- Base persistence wiring updated in [`src/models/base/base_model.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/src/models/base/base_model.py).

### 3) Tests and tracking updates
- Added/expanded targeted tests:
  - [`tests/models/test_checkpoint_helpers.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/tests/models/test_checkpoint_helpers.py)
  - [`tests/models/test_autogluon_base.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/tests/models/test_autogluon_base.py)
  - [`tests/models/test_chronos2_runtime_helpers.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/tests/models/test_chronos2_runtime_helpers.py)
- Added reproducible metrics script:
  - [`scripts/analysis/calc_model_consolidation_metrics.py`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/scripts/analysis/calc_model_consolidation_metrics.py)
- Updated MC1 planning/tracking notes:
  - [`agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md`](https://github.com/Blood-Glucose-Control/nocturnal-hypo-gly-prob-forecast/blob/feat/p1-38-ws1-helper-extraction-c1/agent_notes/P1-38A_METHOD_CONTRACT_CONSOLIDATION_TASK.md)
  - marks MC1 checkpoint helper items complete,
  - clarifies MC2/MC3/MC4 lifecycle carryover work items,
  - refreshes active model-level table with script-derived values.

## Validation

### Targeted lint/type gates
- `ruff check` on all touched Python files (passed).
- `SKIP=pyright pre-commit run --files <touched files>` (passed).
- `pre-commit run pyright --files <model/core touched files>` (passed where hook applies).

### Targeted tests
- `.noctprob-venv`
  - `pytest -q tests/models/test_checkpoint_helpers.py tests/models/test_is_fitted_lifecycle.py`
  - `pytest -q tests/models/test_model_family_contract_suite.py`
  - `pytest -q tests/workflows/forecasting/test_model_config_schema_loader.py -k "ttm or chronos2 or tide"`
- `.venvs/autogluon`
  - `pytest -q tests/models/test_chronos2_runtime_helpers.py tests/models/test_chronos2.py`
- `.venvs/ttm`
  - `pytest -q tests/models/test_ttm_preprocessor_schema_contract.py tests/models/test_ttm_preprocessor_roundtrip.py`
- `.venvs/moment`
  - `pytest -q tests/models/test_moment_sweep_configs.py`

All passed.

### Smoke regression parity
- Ran post-refactor suite:
  - `SUITE_LABEL=post_refactor_20260828_mc1_closeout make smoke-suite-aleppo`
- Manifest:
  - `trained_models/artifacts/regression_smoke/all_models_aleppo/post_refactor_20260828_mc1_closeout/suite_manifest.json`
- Compared against baseline:
  - `trained_models/artifacts/regression_smoke/all_models_aleppo/post_refactor_20260827_c7/suite_manifest.json`
- Comparison:
  - `make smoke-suite-compare BASELINE=... CANDIDATE=... REPORT_PATH=.../comparison_report_vs_c7.json`
  - ✅ passed (`model_count_compared=14`, `failures=[]`, no metric diffs)

## Scope note
- Includes one preparatory Moment refactor commit (`_predict_batch` decomposition) retained on this branch; MC2/MC3/MC4 tracking in P1-38A now explicitly records lifecycle carryover so method ownership remains clear.