### PR TITLE
Fix cached datetime loading issues in holdout validation flow

### DIFF
--- a/configs/data/holdout/brown_2019.yaml
+++ b/configs/data/holdout/brown_2019.yaml
@@ -28,5 +28,5 @@ patient_config:
   - bro_120
   holdout_percentage: null
   min_train_patients: 10
-  min_holdout_patients: 20
+  min_holdout_patients: 16
   random_seed: 42

--- a/src/data/cache_manager.py
+++ b/src/data/cache_manager.py
@@ -474,6 +474,38 @@ class CacheManager:
             f"Saved full processed data for {dataset_name} - {len(data)} patients"
         )
 
+    def _load_cached_patient_csv(self, csv_file: Path) -> pd.DataFrame:
+        """Load a cached patient CSV and normalize datetime index/column shape."""
+        df = pd.read_csv(csv_file, low_memory=False)
+
+        datetime_source_col: str
+        if "datetime" in df.columns:
+            datetime_source_col = "datetime"
+        elif "datetime.1" in df.columns:
+            datetime_source_col = "datetime.1"
+        else:
+            datetime_source_col = str(df.columns[0])
+
+        try:
+            datetime_index = pd.to_datetime(
+                df[datetime_source_col],
+                format="mixed",
+                errors="raise",
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Failed parsing cached datetime values in "
+                f"{csv_file} (column: {datetime_source_col})"
+            ) from exc
+
+        df = df.drop(columns=[datetime_source_col])
+
+        if datetime_source_col == "datetime" and "datetime.1" in df.columns:
+            df = df.drop(columns=["datetime.1"])
+
+        df.index = pd.DatetimeIndex(datetime_index, name="datetime")
+        return df
+
     def load_full_processed_data(
         self, dataset_name: str
     ) -> Optional[Dict[str, pd.DataFrame]]:
@@ -499,10 +531,7 @@ class CacheManager:
                 # Extract patient ID from filename: remove _full.csv suffix
                 FULL_SUFFIX = "_full"
                 patient_id = csv_file.stem[: -len(FULL_SUFFIX)]  # Remove "_full" suffix
-                # Load the CSV with datetime index (first column is the index)
-                df = pd.read_csv(
-                    csv_file, index_col=0, parse_dates=True, low_memory=False
-                )
+                df = self._load_cached_patient_csv(csv_file)
                 result[patient_id] = df
 
             return result if result else None
@@ -648,13 +677,7 @@ class CacheManager:
 
                     if filename.endswith(suffix_to_remove):
                         patient_id = filename[: -len(suffix_to_remove)]
-                        # Load the CSV with datetime index
-                        df = pd.read_csv(
-                            csv_file,
-                            index_col="datetime",
-                            parse_dates=True,
-                            low_memory=False,  # This solved the mixed types warning but not sure it is gonna cause some memory issues.
-                        )
+                        df = self._load_cached_patient_csv(csv_file)
                         result[patient_id] = df
 
                 return result if result else None

--- a/tests/cache_manager/test_cache_system.py
+++ b/tests/cache_manager/test_cache_system.py
@@ -106,6 +106,31 @@ class TestCacheManager:
         pd.testing.assert_frame_equal(data["patient_001"], loaded_data["patient_001"])
         pd.testing.assert_frame_equal(data["patient_002"], loaded_data["patient_002"])
 
+    def test_load_full_processed_data_normalizes_duplicate_datetime_columns(self):
+        """Cached CSVs with duplicate datetime headers should load cleanly."""
+        patient_df = pd.DataFrame(
+            {
+                "datetime": pd.to_datetime(
+                    ["2023-01-01 00:00", "2023-01-01 00:05", "2023-01-01 00:10"]
+                ),
+                "p_num": ["patient_001", "patient_001", "patient_001"],
+                "glucose": [100, 105, 110],
+            }
+        ).set_index("datetime")
+        patient_df["datetime"] = patient_df.index
+
+        self.cache_manager.save_full_processed_data(
+            "test_dataset", {"patient_001": patient_df}
+        )
+        loaded_data = self.cache_manager.load_full_processed_data("test_dataset")
+
+        assert loaded_data is not None
+        loaded_df = loaded_data["patient_001"]
+        assert isinstance(loaded_df.index, pd.DatetimeIndex)
+        assert loaded_df.index.name == "datetime"
+        assert "datetime.1" not in loaded_df.columns
+        assert "datetime" not in loaded_df.columns
+
     def test_load_full_processed_data_not_exists(self):
         """Test loading full processed data when it doesn't exist."""
         with pytest.raises(ValueError, match="Configuration not found"):


### PR DESCRIPTION
## What changed
- Added `_load_cached_patient_csv` in `src/data/cache_manager.py` to normalize cached per-patient CSV loading into a canonical `DatetimeIndex` using explicit `pd.to_datetime(..., format="mixed", errors="raise")`.
- Reused that helper in both `load_full_processed_data` and `load_processed_data` to remove duplicated cache-loading logic and keep behavior consistent.
- Normalized duplicate cached datetime columns (`datetime` + `datetime.1`) so loaders no longer receive malformed frames from cached artifacts.
- Updated `configs/data/holdout/brown_2019.yaml` to set `min_holdout_patients: 16`, matching the fixed holdout patient list in that config.
- Added regression coverage in `tests/cache_manager/test_cache_system.py` for duplicate datetime-column cache cases.

## Why
Running holdout config validators surfaced loader-facing cache issues:
- Cached frames for some patients were loaded with non-datetime indexes and duplicate datetime fields.
- That caused downstream split/validation failures and warnings in loader flows.

This PR makes cached data loading deterministic and loader-safe across datasets.

## Validation
- `./.noctprob-venv/bin/pytest -v --color=yes tests/cache_manager/test_cache_system.py -k "save_and_load_full_processed_data or normalizes_duplicate_datetime_columns"`
  - Result: **2 passed**
- `./.noctprob-venv/bin/python scripts/data_processing/validate_holdout_configs.py tamborlane_2008`
  - Result: **all validations passed**
- `./.noctprob-venv/bin/python scripts/data_processing/validate_holdout_configs.py brown_2019`
  - Result: **all validations passed**
- `./.noctprob-venv/bin/python scripts/data_processing/validate_holdout_configs.py 2>&1 | grep -E "Validating holdout config for:|All validations passed for|Error during validation|Cannot|missing 'datetime' column|Could not infer format"`
  - Result: **all 4 configured datasets passed; no datetime-load warnings/errors in filtered output**
- `SKIP=pyright ./.noctprob-venv/bin/pre-commit run --files src/data/cache_manager.py tests/cache_manager/test_cache_system.py configs/data/holdout/brown_2019.yaml`
  - Result: **passed**
- VS Code Problems/Pylance diagnostics on touched Python files:
  - `src/data/cache_manager.py` ✅
  - `tests/cache_manager/test_cache_system.py` ✅